### PR TITLE
Add support for rp2040 devices

### DIFF
--- a/src/atomvm_pico_flash_provider.erl
+++ b/src/atomvm_pico_flash_provider.erl
@@ -1,0 +1,211 @@
+%%
+%% Copyright (c) 2023 Uncle Grumpy <winford@object.stream>
+%% All rights reserved.
+%%
+%% Based on esp32_flash_provider.erl
+%% Copyright (c) dushin.net
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+-module(atomvm_pico_flash_provider).
+
+-behaviour(provider).
+
+-export([init/1, do/1, format_error/1]).
+
+-include_lib("kernel/include/file.hrl").
+
+-define(PROVIDER, pico_flash).
+-define(DEPS, [uf2create]).
+-define(OPTS, [
+    {path, $p, "path", string,
+        "Path to pico device (Defaults Linux: /run/media/${USER}/RPI-RP2, MacOS: /Volumes/RPI-RP2)"},
+    {reset, $r, "reset", string,
+        "Path to serial device to reset before flashing (Defaults Linux: /dev/ttyACM0, MacOS: /dev/cu.usbmodem14*)"}
+]).
+
+%%
+%% provider implementation
+%%
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+        % The atomvm namespace
+        {namespace, atomvm},
+        % The 'user friendly' name of the task
+        {name, ?PROVIDER},
+        % The module implementation of the task
+        {module, ?MODULE},
+        % The task can be run by the user, always true
+        {bare, true},
+        % The list of dependencies
+        {deps, ?DEPS},
+        % How to use the plugin
+        {example, "rebar3 atomvm pico_flash"},
+        % list of options understood by the plugin
+        {opts, ?OPTS},
+        {short_desc, "A rebar plugin to convert packbeam to uf2 and copy to rp2040 devices"},
+        {desc,
+            "A rebar plugin to convert packbeam to uf2 and copy to rp2040 (Raspberry Pi Pico) devices"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    try
+        Opts = get_opts(rebar_state:command_parsed_args(State)),
+        ok = do_flash(
+            rebar_state:project_apps(State),
+            maps:get(
+                path,
+                Opts,
+                os:getenv("ATOMVM_REBAR3_PLUGIN_PICO_MOUNT_PATH", get_default_mount())
+            ),
+            maps:get(
+                reset, Opts, os:getenv("ATOMVM_REBAR3_PLUGIN_PICO_RESET_DEV", get_reset_dev())
+            )
+        ),
+        {ok, State}
+    catch
+        _:E ->
+            rebar_api:error("~p~n", [E]),
+            {error, E}
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+%%
+%% internal functions
+%%
+
+%% @private
+get_opts({ParsedArgs, _}) ->
+    atomvm_rebar3_plugin:proplist_to_map(ParsedArgs).
+
+%% @private
+get_stty_file_flag() ->
+    System = os:cmd("uname -s"),
+    case System of
+        "Linux\n" ->
+            "-F";
+        _Other ->
+            "-f"
+    end.
+
+%% @private
+get_reset_dev() ->
+    System = os:cmd("uname -s"),
+    case System of
+        "Linux\n" ->
+            "/dev/ttyACM0";
+        "Darwin\n" ->
+            "/dev/cu.usbmodem14*";
+        _Other ->
+            ""
+    end.
+
+%% @private
+get_default_mount() ->
+    System = os:cmd("uname -s"),
+    case System of
+        "Linux\n" ->
+            "/run/media/${USER}/RPI-RP2";
+        "Darwin\n" ->
+            "/Volumes/RPI-RP2";
+        _Other ->
+            ""
+    end.
+
+%% @private
+wait_for_mount(Mount, Count) when Count < 30 ->
+    Cmd = lists:join(" ", [
+        "sh -c \"(test -d", Mount, "&& echo 'true') || echo 'false'\""
+    ]),
+    case os:cmd(Cmd) of
+        "true\n" ->
+            ok;
+        "false\n" ->
+            timer:sleep(1000),
+            wait_for_mount(Mount, Count + 1)
+    end;
+wait_for_mount(Mount, 30) ->
+    rebar_api:error("Pico not mounted at ~s after 30 seconds. giving up...", [Mount]),
+    rebar_api:abort().
+
+%% @private
+check_pico_mount(Mount) ->
+    Cmd = lists:join(" ", [
+        "sh -c \"(test -d", Mount, "&& echo 'true') || echo 'false'\""
+    ]),
+    case os:cmd(Cmd) of
+        "true\n" ->
+            ok;
+        "false\n" ->
+            rebar_api:error("Pico not mounted at ~s.", [Mount]),
+            rebar_api:abort()
+    end.
+
+%% @private
+needs_reset(ResetPort) ->
+    Test = lists:join(" ", [
+        "sh -c \"(test -e",
+        ResetPort,
+        "&& echo 'true') || echo 'false'\""
+    ]),
+    case os:cmd(Test) of
+        "true\n" ->
+            true;
+        "false\n" ->
+            false
+    end.
+
+%% @private
+get_uf2_file(ProjectApps) ->
+    [App | _] = [ProjectApp || ProjectApp <- ProjectApps],
+    OutDir = rebar_app_info:out_dir(App),
+    Name = binary_to_list(rebar_app_info:name(App)),
+    DirName = filename:dirname(OutDir),
+    filename:join(DirName, Name ++ ".uf2").
+
+%% @private
+do_flash(ProjectApps, PicoPath, ResetPort) ->
+    case needs_reset(ResetPort) of
+        false ->
+            ok;
+        true ->
+            Flag = get_stty_file_flag(),
+            Reset = lists:join(" ", [
+                "stty", Flag, ResetPort, "1200"
+            ]),
+            rebar_api:info("Resetting device at path ~s", [ResetPort]),
+            ResetStatus = os:cmd(Reset),
+            case ResetStatus of
+                "" ->
+                    ok;
+                _Any ->
+                    rebar_api:error("Reset ~s failed. Is tty console attached?", [ResetPort]),
+                    rebar_api:abort()
+            end,
+            rebar_api:info("Waiting for the device at path ~s to settle and mount...", [PicoPath]),
+            wait_for_mount(PicoPath, 0)
+    end,
+    check_pico_mount(PicoPath),
+    TargetUF2 = get_uf2_file(ProjectApps),
+    Cmd = lists:join(" ", [
+        "cp", "-v", TargetUF2, PicoPath
+    ]),
+    rebar_api:info("~s~n", [Cmd]),
+    io:format("~s", [os:cmd(Cmd)]),
+    ok.

--- a/src/atomvm_rebar3_plugin.erl
+++ b/src/atomvm_rebar3_plugin.erl
@@ -24,7 +24,9 @@
 -define(PROVIDERS, [
     atomvm_packbeam_provider,
     atomvm_esp32_flash_provider,
+    atomvm_pico_flash_provider,
     atomvm_stm32_flash_provider,
+    atomvm_uf2create_provider,
     legacy_packbeam_provider,
     legacy_esp32_flash_provider,
     legacy_stm32_flash_provider

--- a/src/atomvm_uf2create_provider.erl
+++ b/src/atomvm_uf2create_provider.erl
@@ -1,0 +1,178 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+%
+% Adapted for atomvm_rebar3_plugin:
+% Copyright 2023 Winford (UncleGrumpy) <winford@object.stream>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(atomvm_uf2create_provider).
+
+-behaviour(provider).
+
+-export([init/1, do/1, format_error/1]).
+
+-include_lib("kernel/include/file.hrl").
+
+-define(PROVIDER, uf2create).
+-define(DEPS, [packbeam]).
+-define(OPTS, [
+    {output, $o, "output", string, "Output path/name"},
+    {start, $s, "start", string, "Start address for the uf2 binary (default 0x10180000)"},
+    {input, $i, "input", string, "Input avm file to convert to uf2"}
+]).
+
+%%
+%% provider implementation
+%%
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+        % The atomvm namespace
+        {namespace, atomvm},
+        % The 'user friendly' name of the task
+        {name, ?PROVIDER},
+        % The module implementation of the task
+        {module, ?MODULE},
+        % The task can be run by the user, always true
+        {bare, true},
+        % The list of dependencies
+        {deps, ?DEPS},
+        % How to use the plugin
+        {example, "rebar3 atomvm uf2create"},
+        % list of options understood by the plugin
+        {opts, ?OPTS},
+        {short_desc, "A rebar plugin to create uf2 files"},
+        {desc, "A rebar plugin to create uf2 files from packbeam files"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    try
+        Opts = get_opts(rebar_state:command_parsed_args(State)),
+        OutFile = get_out_file(State),
+        TargetAVM = get_avm_file(State),
+        ok = do_uf2create(
+            maps:get(output, Opts, OutFile),
+            parse_addr(maps:get(start, Opts, "0x10180000")),
+            maps:get(input, Opts, TargetAVM)
+        ),
+        {ok, State}
+    catch
+        _:E ->
+            rebar_api:error("~p~n", [E]),
+            {error, E}
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+
+%%
+%% internal functions
+%%
+
+%% @private
+get_opts({ParsedArgs, _}) ->
+    atomvm_rebar3_plugin:proplist_to_map(ParsedArgs).
+
+%% @private
+get_avm_file(State) ->
+    [App] = [ProjectApp || ProjectApp <- rebar_state:project_apps(State)],
+    OutDir = rebar_app_info:out_dir(App),
+    Name = binary_to_list(rebar_app_info:name(App)),
+    DirName = filename:dirname(OutDir),
+    filename:join(DirName, Name ++ ".avm").
+
+%% @private
+get_out_file(State) ->
+    [App] = [ProjectApp || ProjectApp <- rebar_state:project_apps(State)],
+    OutDir = rebar_app_info:out_dir(App),
+    Name = binary_to_list(rebar_app_info:name(App)),
+    DirName = filename:dirname(OutDir),
+    filename:join(DirName, Name ++ ".uf2").
+
+%% @private
+parse_addr("0x" ++ AddrHex) ->
+    list_to_integer(AddrHex, 16);
+parse_addr("16#" ++ AddrHex) ->
+    list_to_integer(AddrHex, 16);
+parse_addr(AddrDec) ->
+    list_to_integer(AddrDec).
+
+%%% UF2 defines
+-define(UF2_MAGIC_START0, 16#0A324655).
+-define(UF2_MAGIC_START1, 16#9E5D5157).
+-define(UF2_MAGIC_END, 16#0AB16F30).
+
+-define(UF2_FLAG_FAMILY_ID_PRESENT, 16#00002000).
+
+%%% Pico defines
+-define(UF2_PICO_FLAGS, ?UF2_FLAG_FAMILY_ID_PRESENT).
+-define(UF2_PICO_PAGE_SIZE, 256).
+-define(UF2_PICO_FAMILY_ID, 16#E48BFF56).
+
+%%%
+
+do_uf2create(OutputPath, StartAddr, ImagePath) ->
+    {ok, ImageBin} = file:read_file(ImagePath),
+    BlocksCount0 = byte_size(ImageBin) div ?UF2_PICO_PAGE_SIZE,
+    BlocksCount =
+        BlocksCount0 +
+            if
+                byte_size(ImageBin) rem ?UF2_PICO_PAGE_SIZE =:= 0 -> 0;
+                true -> 1
+            end,
+    OutputBin = uf2create0(0, BlocksCount, StartAddr, ImageBin, []),
+    ok = file:write_file(OutputPath, OutputBin).
+
+%% @private
+uf2create0(_BlockIndex, _BlocksCount, _BaseAddr, <<>>, Acc) ->
+    lists:reverse(Acc);
+uf2create0(BlockIndex, BlocksCount, BaseAddr, ImageBin, Acc) ->
+    {PageBin, Tail} =
+        if
+            byte_size(ImageBin) >= ?UF2_PICO_PAGE_SIZE ->
+                split_binary(ImageBin, ?UF2_PICO_PAGE_SIZE);
+            true ->
+                {ImageBin, <<>>}
+        end,
+    PaddedData = pad_binary(PageBin, 476),
+    Block = [
+        <<
+            ?UF2_MAGIC_START0:32/little,
+            ?UF2_MAGIC_START1:32/little,
+            ?UF2_PICO_FLAGS:32/little,
+            BaseAddr:32/little,
+            ?UF2_PICO_PAGE_SIZE:32/little,
+            BlockIndex:32/little,
+            BlocksCount:32/little,
+            ?UF2_PICO_FAMILY_ID:32/little
+        >>,
+        PaddedData,
+        <<?UF2_MAGIC_END:32/little>>
+    ],
+    uf2create0(BlockIndex + 1, BlocksCount, BaseAddr + ?UF2_PICO_PAGE_SIZE, Tail, [Block | Acc]).
+
+%% @private
+pad_binary(Bin, Len) ->
+    PadCount = Len - byte_size(Bin),
+    Pad = binary:copy(<<0>>, PadCount),
+    [Bin, Pad].


### PR DESCRIPTION
Adds `uf2create_provider` to support converting packed .avm applications into the uf2 format used by RPi Pico devices.
Adds `pico_flash_provider` to copy the application to the pico device mounted at the path specified by `-p`, `--path`, or by setting `ATOMVM_REBAR3_PLUGIN_PICO_DEV_PATH` to the device path in the user environment. The `pico_flash_provider` depends on `uf2create_provider` which in turn depends on `packbeam`, so it is only necessary to use `rebar3 pico_flash -p /PATH/TO/DEVICE` to compile, pack, reformat, and copy the file to the pico. The device path can be omitted if `ATOMVM_REBAR3_PLUGIN_PICO_DEV_PATH` is set in the environment to the correct path.