### PR TITLE
Moved atomvm commands under the atomvm namespace

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] (Unreleased)
+
+Moved atomvm targets under the `atomvm` namespace
+
 ## [0.6.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 A `rebar3` plugin for simplifying development of Erlang applications targeted for the <a href="http://github.com/bettio/AtomVM">AtomVM</a> Erlang abstract machine.
 
-This `rebar3` plugin provides the following targets:
+This `rebar3` plugin provides the following targets under the `atomvm` namespace:
 
 * `packbeam`  Generate AtomVM packbeam files from your `rebar3` project and its dependencies.
 * `esp32_flash`  Flash AtomVM packbeam files to ESP32 devices over a serial connection.
+* `stm32_flash`  Flash AtomVM packbeam files to STM32 devices over a serial connection.
+
+> Note. The above targets were previously under the default namespace; however, the commands under the default namespace have been DEPRECATED.
 
 The `atomvm_rebar3_plugin` plugin makes use of the <a href="https://github.com/fadushin/packbeam">packbeam</a> tool, internally.
 
@@ -41,7 +44,7 @@ Create a file called main.erl in the `src` directory with the contents:
 
 Use the `packbeam` target to create an AVM file:
 
-    shell$ rebar3 packbeam
+    shell$ rebar3 atomvm packbeam
     ===> Analyzing applications...
     ===> Compiling atomvm_rebar3_plugin
     ===> Compiling packbeam
@@ -64,10 +67,10 @@ You can use the [`packbeam`](https://github.com/atomvm/atomvm_packbeam) tool to 
 
 The `packbeam` target is used to generated an AtomVM packbeam (`.avm`) file.
 
-    shell$ rebar3 help packbeam
+    shell$ rebar3 help atovm packbeam
     ...
     A rebar plugin to create packbeam files
-    Usage: rebar3 packbeam [-e] [-f] [-p] [-i] [-r] [-s <start>]
+    Usage: rebar3 atomvm packbeam [-e] [-f] [-p] [-i] [-r] [-s <start>]
 
     -e, --external       External AVM modules
     -f, --force          Force rebuild
@@ -79,7 +82,7 @@ The `packbeam` target is used to generated an AtomVM packbeam (`.avm`) file.
     -s, --start          Start module
 E.g.,
 
-    shell$ rebar3 packbeam
+    shell$ rebar3 atomvm packbeam
     ===> Compiling packbeam
     ===> Compiling atomvm_rebar3_plugin
     ===> Compiling packbeam
@@ -97,7 +100,7 @@ If your project has any erlang dependencies, the `packbeam` target will include 
 
 If your project (or any of its dependencies) has multiple modules that export a `start/0` entry-point function, you can specify which module to use as the entry-point for your application via the `--start` (or `-s`) option:
 
-    shell$ rebar3 packbeam --start my_start_module
+    shell$ rebar3 atomvm packbeam --start my_start_module
     ...
 
 Using this option will ensure that the generated AVM file with use `my_start_module` to start the application.
@@ -149,7 +152,7 @@ And the application configuration file (e.g., `myapp.app.src`) should include th
 
 If you specify `init` as the start module, then an AVM file will be created:
 
-    shell$ rebar3 packbeam -p -s init
+    shell$ rebar3 atovm packbeam -p -s init
     ===> Analyzing applications...
     ===> Compiling atomvm_rebar3_plugin
     ===> Compiling packbeam
@@ -177,7 +180,7 @@ Running this AVM file will boot the `myapp` application automatically, without h
 
 If you already have AVM modules are not available via `rebar3`, you can direct the `packbeam` target to these AVM files via the `-e` (or `--external`) flag, e.g.,
 
-    shell$ rebar3 packbeam -e <path-to-avm-1> -e <path-to-avm-2> ...
+    shell$ rebar3 atomvm packbeam -e <path-to-avm-1> -e <path-to-avm-2> ...
     ===> Fetching packbeam
     ===> Compiling packbeam
     ===> Compiling atomvm_rebar3_plugin
@@ -196,7 +199,7 @@ You can use the `-r` or `--remove_lines` flags to packbeam, to remove line infor
 
 You may use the `esp32_flash` target to flash the generated AtomVM packbeam application to the flash storage on an ESP32 device connected over a serial connection.
 
-    shell$ rebar3 help esp32_flash
+    shell$ rebar3 help atomvm esp32_flash
     ...
     A rebar plugin to flash packbeam to ESP32 devices
     Usage: rebar3 esp32_flash [-e] [-p] [-b] [-o]
@@ -213,7 +216,7 @@ By default, the `esp32_flash` target will assume the `esptool.py` command is ava
 
 By default, the `esp32_flash` target will write to port `/dev/ttyUSB0` at a baud rate of `115200`.  You may control the port and baud settings for connecting to your ESP device via the `-port` and `-baud` options to the `esp32_flash` target, e.g.,
 
-    shell$ rebar3 esp32_flash --port /dev/tty.SLAB_USBtoUART --baud 921600
+    shell$ rebar3 atomvm esp32_flash --port /dev/tty.SLAB_USBtoUART --baud 921600
     ===> Compiling packbeam
     ===> Compiling atomvm_rebar3_plugin
     ===> Compiling packbeam
@@ -249,19 +252,19 @@ Any setting specified on the command line take precedence over environment varia
 
 The `esp32_flash` target depends on the `packbeam` target, so any changes to modules in the project will get rebuilt before being flashed to the device.
 
-## The `stm32-flash` target
+## The `stm32_flash` target
 
 ### Preparing an application for flashing
 The stm32 builds of AtomVM do not include a library partition and atomvmlib.avm is not flashed to the device. Instead the application should be compiled and packed along with atomvmlib.avm before flashing, for example:
 
-    shell$ rebar3 packbeam -p -e /path/to/atomvmlib.avm
+    shell$ rebar3 atomvm packbeam -p -e /path/to/atomvmlib.avm
 
 Consult `rebar3 help packbeam` for other options.
 
 ### Flashing an application to a stm32 device
 You may use the `stm32_flash` target to flash the generated AtomVM packbeam application to the flash storage on an STM32 device connected to an st-link.
 
-    shell$ rebar3 help stm32_flash
+    shell$ rebar3 help atomvm stm32_flash
     A rebar plugin to flash packbeam to STM32 devices
     Usage: rebar3 stm32_flash [-s] [-o]
 
@@ -272,7 +275,7 @@ The `stm32_flash` will use the `st-flash` tool from the open source (bsd-3 lisce
 
 By default, the `stm32_flash` target will assume the `st-flash` command is available on the user's executable path.  Alternatively, you may specify the full path to the `st-flash` command via the `-s` (or `--stflash`) option
 
-    shell$ rebar3 stm32_flash --stflash /usr/bin/st-flash --offset 0x8080000
+    shell$ rebar3 atomvm stm32_flash --stflash /usr/bin/st-flash --offset 0x8080000
     ===> Verifying dependencies...
     ===> Analyzing applications...
     ===> Compiling stm32_hello

--- a/src/atomvm_esp32_flash_provider.erl
+++ b/src/atomvm_esp32_flash_provider.erl
@@ -14,7 +14,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
--module(esp32_flash_provider).
+-module(atomvm_esp32_flash_provider).
 
 -behaviour(provider).
 
@@ -38,6 +38,8 @@
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
     Provider = providers:create([
+        % The atomvm namespace
+        {namespace, atomvm},
         % The 'user friendly' name of the task
         {name, ?PROVIDER},
         % The module implementation of the task
@@ -47,7 +49,7 @@ init(State) ->
         % The list of dependencies
         {deps, ?DEPS},
         % How to use the plugin
-        {example, "rebar3 esp32_flash"},
+        {example, "rebar3 atomvm esp32_flash"},
         % list of options understood by the plugin
         {opts, ?OPTS},
         {short_desc, "A rebar plugin to flash packbeam to ESP32 devices"},

--- a/src/atomvm_packbeam_provider.erl
+++ b/src/atomvm_packbeam_provider.erl
@@ -14,7 +14,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
--module(packbeam_provider).
+-module(atomvm_packbeam_provider).
 
 -behaviour(provider).
 
@@ -23,7 +23,7 @@
 -include_lib("kernel/include/file.hrl").
 
 -define(PROVIDER, packbeam).
--define(DEPS, [compile]).
+-define(DEPS, [{default, compile}]).
 -define(OPTS, [
     {ext, $e, "external", undefined, "External AVM modules"},
     {force, $f, "force", undefined, "Force rebuild"},
@@ -39,6 +39,8 @@
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
     Provider = providers:create([
+        % The atomvm namespace
+        {namespace, atomvm},
         % The 'user friendly' name of the task
         {name, ?PROVIDER},
         % The module implementation of the task
@@ -48,7 +50,7 @@ init(State) ->
         % The list of dependencies
         {deps, ?DEPS},
         % How to use the plugin
-        {example, "rebar3 packbeam"},
+        {example, "rebar3 atomvm packbeam"},
         % list of options understood by the plugin
         {opts, ?OPTS},
         {short_desc, "A rebar plugin to create packbeam files"},

--- a/src/atomvm_rebar3_plugin.app.src
+++ b/src/atomvm_rebar3_plugin.app.src
@@ -16,7 +16,7 @@
 %%
 {application, atomvm_rebar3_plugin, [
     {description, "A rebar plugin for manipulating AtomVM AVM files"},
-    {vsn, "0.6.1"},
+    {vsn, "0.7.0"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, []},

--- a/src/atomvm_rebar3_plugin.erl
+++ b/src/atomvm_rebar3_plugin.erl
@@ -18,9 +18,21 @@
 
 -export([init/1]).
 
+-define(PROVIDERS, [
+    atomvm_packbeam_provider,
+    atomvm_esp32_flash_provider,
+    atomvm_stm32_flash_provider,
+    legacy_packbeam_provider,
+    legacy_esp32_flash_provider,
+    legacy_stm32_flash_provider
+]).
+
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-    {ok, State1} = packbeam_provider:init(State),
-    {ok, State2} = esp32_flash_provider:init(State1),
-    {ok, State3} = stm32_flash_provider:init(State2),
-    {ok, State3}.
+    lists:foldl(
+        fun(Cmd, {ok, StateAcc}) ->
+            apply(Cmd, init, [StateAcc])
+        end,
+        {ok, State},
+        ?PROVIDERS
+    ).

--- a/src/atomvm_stm32_flash_provider.erl
+++ b/src/atomvm_stm32_flash_provider.erl
@@ -17,7 +17,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
--module(stm32_flash_provider).
+-module(atomvm_stm32_flash_provider).
 
 -behaviour(provider).
 
@@ -38,6 +38,8 @@
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
     Provider = providers:create([
+        % The atomvm namespace
+        {namespace, atomvm},
         % The 'user friendly' name of the task
         {name, ?PROVIDER},
         % The module implementation of the task
@@ -47,7 +49,7 @@ init(State) ->
         % The list of dependencies
         {deps, ?DEPS},
         % How to use the plugin
-        {example, "rebar3 stm32_flash"},
+        {example, "rebar3 atomvm stm32_flash"},
         % list of options understood by the plugin
         {opts, ?OPTS},
         {short_desc, "A rebar plugin to flash packbeam to STM32 devices"},

--- a/src/legacy_esp32_flash_provider.erl
+++ b/src/legacy_esp32_flash_provider.erl
@@ -1,0 +1,65 @@
+%%
+%% Copyright (c) dushin.net
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+-module(legacy_esp32_flash_provider).
+
+-behaviour(provider).
+
+-export([init/1, do/1, format_error/1]).
+
+-include_lib("kernel/include/file.hrl").
+
+-define(PROVIDER, esp32_flash).
+-define(DEPS, [packbeam]).
+-define(OPTS, [
+    {esptool, $e, "esptool", undefined, "Path to esptool.py"},
+    {chip, $c, "chip", undefined, "ESP chip (default auto)"},
+    {port, $p, "port", undefined, "Device port (default /dev/ttyUSB0)"},
+    {baud, $b, "baud", undefined, "Baud rate (default 115200)"},
+    {offset, $o, "offset", undefined, "Offset (default 0x210000)"}
+]).
+
+%%
+%% provider implementation
+%%
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+        % The 'user friendly' name of the task
+        {name, ?PROVIDER},
+        % The module implementation of the task
+        {module, ?MODULE},
+        % The task can be run by the user, always true
+        {bare, true},
+        % The list of dependencies
+        {deps, ?DEPS},
+        % How to use the plugin
+        {example, "rebar3 esp32_flash"},
+        % list of options understood by the plugin
+        {opts, ?OPTS},
+        {short_desc, "A rebar plugin to flash packbeam to ESP32 devices (DEPRECATED)"},
+        {desc, "A rebar plugin to flash packbeam to ESP32 devices (DEPRECATED)"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    rebar_api:warn("DEPRECATED The esp32_flash tool has been moved under the atomvm namespace", []),
+    atomvm_esp32_flash_provider:do(State).
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    atomvm_esp32_flash_provider:format_error(Reason).

--- a/src/legacy_packbeam_provider.erl
+++ b/src/legacy_packbeam_provider.erl
@@ -1,0 +1,65 @@
+%%
+%% Copyright (c) dushin.net
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+-module(legacy_packbeam_provider).
+
+-behaviour(provider).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, packbeam).
+-define(DEPS, [{default, compile}]).
+-define(OPTS, [
+    {ext, $e, "external", undefined, "External AVM modules"},
+    {force, $f, "force", undefined, "Force rebuild"},
+    {prune, $p, "prune", undefined, "Prune unreferenced BEAM files"},
+    {include_lines, $i, "include_lines", undefined, "Include line information in generated AVM files (deprecated)"},
+    {remove_lines, $r, "remove_lines", undefined, "Remove line information from generated AVM files (off by default)"},
+    {start, $s, "start", atom, "Start module"}
+]).
+
+%%
+%% provider implementation
+%%
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+        % The 'user friendly' name of the task
+        {name, ?PROVIDER},
+        % The module implementation of the task
+        {module, ?MODULE},
+        % The task can be run by the user, always true
+        {bare, true},
+        % The list of dependencies
+        {deps, ?DEPS},
+        % How to use the plugin
+        {example, "rebar3 packbeam"},
+        % list of options understood by the plugin
+        {opts, ?OPTS},
+        {short_desc, "A rebar plugin to create packbeam files (DEPRECATED)"},
+        {desc, "A rebar plugin to create packbeam files (DEPRECATED)"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    rebar_api:warn("DEPRECATED The packbeam tool has been moved under the atomvm namespace", []),
+    atomvm_packbeam_provider:do(State).
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    atomvm_packbeam_provider:format_error(Reason).
+

--- a/src/legacy_stm32_flash_provider.erl
+++ b/src/legacy_stm32_flash_provider.erl
@@ -1,0 +1,64 @@
+%%
+%% Copyright (c) 2023 Uncle Grumpy <winford@object.stream>
+%% All rights reserved.
+%%
+%% Based on esp32_flash_provider.erl
+%% Copyright (c) dushin.net
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+-module(legacy_stm32_flash_provider).
+
+-behaviour(provider).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, stm32_flash).
+-define(DEPS, [packbeam]).
+-define(OPTS, [
+    {stflash, $s, "stflash", undefined, "Path to st-flash"},
+    {offset, $o, "offset", undefined, "Offset (default 0x8080000)"}
+]).
+
+%%
+%% provider implementation
+%%
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+        % The 'user friendly' name of the task
+        {name, ?PROVIDER},
+        % The module implementation of the task
+        {module, ?MODULE},
+        % The task can be run by the user, always true
+        {bare, true},
+        % The list of dependencies
+        {deps, ?DEPS},
+        % How to use the plugin
+        {example, "rebar3 stm32_flash"},
+        % list of options understood by the plugin
+        {opts, ?OPTS},
+        {short_desc, "A rebar plugin to flash packbeam to STM32 devices (DEPRECATED)"},
+        {desc, "A rebar plugin to flash packbeam to STM32 devices (DEPRECATED)"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    rebar_api:warn("DEPRECATED The stm32_flash tool has been moved under the atomvm namespace", []),
+    atomvm_stm32_flash_provider:do(State).
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    atomvm_stm32_flash_provider:format_error(Reason).
+


### PR DESCRIPTION
The “legacy” commands in the default namespace are still functional but are deprecated.  When users use the commands in the default namespace, they will receive a DEPRECATION warning on the console.