### PR TITLE
rebar.config missing entry fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1]
+
+- Fixed a bug whereby a missing `atomvm_rebar3_plugin` entry in `rebar.config` would crash the `packbeam` task.
+
 ## [0.7.0]
 
 - Moved atomvm tasks under the `atomvm` namespace (with support for deprecated tasks in the default namespace)

--- a/README.md
+++ b/README.md
@@ -148,12 +148,15 @@ If you would like to view the contents of the AVM file after you have created it
 The following table enumerates the properties that may be defined in your project's `rebar.config`
 file for this task.  Use `packbeam` as the key for any properties defined for this task.
 
+> Note that the `--list` flag is only operative when the AVM file has been written.  Use the `--force` (`-f`) flag to force a rebuild of the AVM file, if desired.
+
 | Key | Type | Description |
 |-----|------|-------------|
 | `force` | `boolean()` | Always force a rebuild of the AVM file, even if up to date |
 | `prune` | `boolean()` | Prune unecessary BEAM files from generated AVM |
 | `start` | `atom()` | The start module |
 | `remove_lines` | `boolean()` | Remove line number information from generated AVM files.  |
+| `list` | `boolean()` | List the AVM file contents when generating AVM files.  |
 
 Example:
 

--- a/src/atomvm_esp32_flash_provider.erl
+++ b/src/atomvm_esp32_flash_provider.erl
@@ -83,8 +83,8 @@ do(State) ->
         ),
         {ok, State}
     catch
-        _:E ->
-            rebar_api:error("~p~n", [E]),
+        C:E:S ->
+            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
             {error, E}
     end.
 

--- a/src/atomvm_packbeam_provider.erl
+++ b/src/atomvm_packbeam_provider.erl
@@ -91,8 +91,8 @@ do(State) ->
         ),
         {ok, State}
     catch
-        _:E ->
-            rebar_api:error("~p~n", [E]),
+        C:E:S ->
+            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
             {error, E}
     end.
 

--- a/src/atomvm_pico_flash_provider.erl
+++ b/src/atomvm_pico_flash_provider.erl
@@ -74,8 +74,8 @@ do(State) ->
         ),
         {ok, State}
     catch
-        _:E ->
-            rebar_api:error("~p~n", [E]),
+        C:E:S ->
+            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
             {error, E}
     end.
 

--- a/src/atomvm_rebar3_plugin.erl
+++ b/src/atomvm_rebar3_plugin.erl
@@ -58,7 +58,7 @@ proplist_to_map([K | T], Accum) ->
 
 -spec get_atomvm_rebar_provider_config(State :: term(), Provider :: atom()) -> map().
 get_atomvm_rebar_provider_config(State, Provider) ->
-    case rebar_state:get(State, ?MODULE) of
+    case rebar_state:get(State, ?MODULE, undefined) of
         undefined ->
             #{};
         AtomVM ->

--- a/src/atomvm_stm32_flash_provider.erl
+++ b/src/atomvm_stm32_flash_provider.erl
@@ -77,8 +77,8 @@ do(State) ->
         ),
         {ok, State}
     catch
-        _:E ->
-            rebar_api:error("~p~n", [E]),
+        C:E:S ->
+            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
             {error, E}
     end.
 

--- a/src/atomvm_uf2create_provider.erl
+++ b/src/atomvm_uf2create_provider.erl
@@ -83,8 +83,8 @@ do(State) ->
         ),
         {ok, State}
     catch
-        _:E ->
-            rebar_api:error("~p~n", [E]),
+        C:E:S ->
+            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
             {error, E}
     end.
 


### PR DESCRIPTION
Fixed a bug whereby a missing `atomvm_rebar3_plugin` entry in `rebar config` would crash the `packbeam` task