### PR TITLE
Write bootstrap files into their own bootstrap_ebin directory

### DIFF
--- a/src/atomvm_bootstrap_provider.erl
+++ b/src/atomvm_bootstrap_provider.erl
@@ -136,8 +136,19 @@ do_bootstrap_app(App, BootstrapDir, Force) ->
 %% @private
 do_bootstrap_file(App, BootstrapFile, Force) ->
     OutDir = rebar_app_info:out_dir(App),
-    EBinDir = filename:join(OutDir, "ebin"),
+    EBinDir = filename:join(OutDir, "bootstrap_ebin"),
+    ok = ensure_path(EBinDir),
     maybe_compile(App, BootstrapFile, EBinDir, Force).
+
+%% @private
+ensure_path(Dir) ->
+    case filelib:is_dir(Dir) of
+        true ->
+            ok;
+        _ ->
+            ok = filelib:ensure_dir(Dir),
+            ok = file:make_dir(Dir)
+    end.
 
 %% @private
 maybe_compile(App, BootstrapFile, EBinDir, Force) ->
@@ -152,7 +163,7 @@ maybe_compile(App, BootstrapFile, EBinDir, Force) ->
                 BootstrapFile, CompilerOptions
             ) of
                 {ok, ModuleName} ->
-                    rebar_api:info("Compiled bootstrap module ~p", [ModuleName]),
+                    rebar_api:debug("Compiled bootstrap module ~p", [ModuleName]),
                     ok;
                 Error ->
                     rebar_api:error("Failed to compile bootstrap file ~s: ~p", [BootstrapFile, Error]),

--- a/test/driver/src/bootstrap_tests.erl
+++ b/test/driver/src/bootstrap_tests.erl
@@ -33,8 +33,7 @@ test_bootstrap_task(Opts) ->
     Output = test:execute_cmd(Cmd, Opts),
     test:debug(Output, Opts),
 
-    ok = test:expect_contains("Compiled bootstrap module application", Output),
-    AppblicationBeamPath = test:make_path([AppDir, "_build/default/lib/myapp/ebin/application.beam"]),
+    AppblicationBeamPath = test:make_path([AppDir, "_build/default/lib/myapp/bootstrap_ebin/application.beam"]),
     ok = test:file_exists(AppblicationBeamPath),
 
     test:tick().


### PR DESCRIPTION
Write bootstrap files into their own bootstrap_ebin directory, so they do not trip up rebar when re-building (and potentially loading bootstrap files).

Also, strip paths of whitespace for cases in which quoted paths are provided with leading or trailing whitespace.