### PR TITLE
Fix new atomvm_app name in rebar.config

### DIFF
--- a/priv/rebar.config
+++ b/priv/rebar.config
@@ -21,5 +21,5 @@
     atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
-    {packbeam, [{start, myapp}, prune]}
+    {packbeam, [{start, {{name}}}, prune]}
 ]}.


### PR DESCRIPTION
Fixes the rebar.config template file for new applications created with `rebar3 atomvm new atomvm_app ${{name}}` to insert the newly created application name in the rebar.config file for the appliction, rather than always using `myapp` for the application name.