### PR TITLE
Fix typo in `atomvm_app` README.md

### DIFF
--- a/priv/README.md
+++ b/priv/README.md
@@ -2,4 +2,4 @@
 
 Welcome to the {{name}} AtomVM application.
 
-For informtion about how to build and flash this application, see the [`atomvm_rebar3_plugin`](https://github.com/atomvm/atomvm_rebar3_plugin) Github repository.
+For information about how to build and flash this application, see the [`atomvm_rebar3_plugin`](https://github.com/atomvm/atomvm_rebar3_plugin) Github repository.


### PR DESCRIPTION
There was a type in the generated README.md file inlcluded in new applications created with the `rebar3 atomvm new atomvm_app` template.