### PR TITLE
Prepare v0.7.4 release

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        otp: ["25", "26", "27"]
+        otp: ["25", "26", "27", "28"]
 
     steps:
     # Setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.4] (unreleased)
+## [0.7.4] (2024.06.06)
 
+### Added
 - Added support for the `--application` (or `-a`) option to support AtomVM OTP applications.
+- Support for OTP 28 (in updated atomvm_packeam 0.7.4)
+
+### Fixed
+- Fixed the `rebar3 new atomvm_app`  template rebar.config file to use the provided app name for the start module.
 
 ### Changed
 
 - Using the `-s init` option is still supported but deprecated.  Use the `--application` (or `-a`) option to generate OTP applications using AtomVM.
 - Replace `atomvm_uf2create_provider` uf2 creation code with [upstream `uf2tool`](https://github.com/pguyot/uf2tool)
+- `pico_flash` task now uses picotool to reset the rp2040 device if a serial monitor is attached.
+- Update `atomvm_packbeam` dependency to 0.7.4.
 
 ## [0.7.3] (2023.11.25)
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,10 @@ The `stm32_flash` task depends on the `packbeam` task, so the packbeam file will
 
 #### Flashing an application to a pico (rp2040) device
 
-You may use the `pico_flash` task to copy the generated AtomVM packbeam application in uf2 format to the flash storage on an Pico device connected to usb. It is not necessary to push the `BOOTSEL` button while plugging in the Pico to usb, instead provide the path of the device to reset. On Linux this is typically `/dev/ttyACM0` (the same device used to monitor serial), on MacOS it is a cu.usbmodem device matching `/dev/cu.usbmodem14*` (not the /dev/tty.usbmodem14___ device used for serial monitoring).
+You may use the `pico_flash` task to copy the generated AtomVM packbeam application in uf2 format to the flash storage on an Pico device connected to usb. It is not necessary to push the `BOOTSEL` button while plugging in the Pico to usb, instead provide the path of the device to reset. On Linux this is typically `/dev/ttyACM0` (the same device used to monitor serial), on MacOS it is a cu.usbmodem device matching `/dev/cu.usbmodem14*` (not the /dev/tty.usbmodem14___ device used for serial monitoring). It is highly recommended
+that `picotool` is installed in your PATH. If it is found in the PATH the automatic `BOOTSEL` and mode can be activated even if you have an active terminal monitor (tmux, minicom, or screen) in another terminal it will
+be disconnected automatically. With `picotool` in your PATH the device has a higher success rate of resetting and entering `application` mode after flashing. Without `picotool` some small applications do not always
+trigger a reset into `application` mode after flashing with `rebar3 atomvm pico_flash`.
 
     shell$ rebar3 help atomvm pico_flash
 
@@ -403,7 +406,7 @@ You may use the `pico_flash` task to copy the generated AtomVM packbeam applicat
     -r, --reset  Path to serial device to reset before flashing (Defaults
                 Linux: /dev/ttyACM0, MacOS: /dev/cu.usbmodem14*)
 
-The `pico_flash` task depends on the `uf2create` task which in turn depends on `packbeam`, so in most cases it is not necessary to execute either of those tasks if the default settings are used, as any changes to modules in the project will get rebuilt before being flashed to the device.
+The `pico_flash` task depends on the `uf2create` task which in turn depends on the `packbeam` task, so in most cases it is not necessary to execute either of those tasks if the default settings are used, as any changes to modules in the project will get rebuilt before being flashed to the device.
 
     shell$ rebar3 atomvm pico_flash
     ===> Fetching atomvm_rebar3_plugin v0.7.3

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Configuration in `rebar.config` is optional but can be useful in some cases.  Fo
 
 The `packbeam` task is used to generated an AtomVM packbeam (`.avm`) file.
 
-    shell$ rebar3 help atovm packbeam
+    shell$ rebar3 help atomvm packbeam
 
     Use this plugin to create an AtomVM packbeam file from your rebar3 project.
 
@@ -409,7 +409,7 @@ trigger a reset into `application` mode after flashing with `rebar3 atomvm pico_
 The `pico_flash` task depends on the `uf2create` task which in turn depends on the `packbeam` task, so in most cases it is not necessary to execute either of those tasks if the default settings are used, as any changes to modules in the project will get rebuilt before being flashed to the device.
 
     shell$ rebar3 atomvm pico_flash
-    ===> Fetching atomvm_rebar3_plugin v0.7.3
+    ===> Fetching atomvm_rebar3_plugin v0.7.4
     ===> Fetching rebar3_hex v7.0.6
     ===> Fetching hex_core v0.8.4
     ===> Fetching verl v1.1.1
@@ -417,7 +417,7 @@ The `pico_flash` task depends on the `uf2create` task which in turn depends on t
     ===> Compiling hex_core
     ===> Compiling verl
     ===> Compiling rebar3_hex
-    ===> Fetching atomvm_packbeam v0.6.0
+    ===> Fetching atomvm_packbeam v0.7.4
     ===> Fetching rebar3_proper v0.12.1
     ===> Analyzing applications...
     ===> Compiling rebar3_proper
@@ -520,7 +520,7 @@ The `uf2create` task depends on the `packbeam` task, so the packbeam file will g
 use the `version` task to print the current version of the [`atomvm_rebar3_plugin`](https://atomvm.github.io/atomvm_rebar3_plugin) to the console.
 
     shell$ rebar3 atomvm version
-    0.7.3
+    0.7.4
 
 ### The `bootstrap` task
 

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {atomvm_packbeam, "0.7.2"},
+    {atomvm_packbeam, "0.7.4"},
     {uf2tool, {git, "https://github.com/pguyot/uf2tool.git", {tag, "v1.1.0"}}}
 ]}.
 

--- a/src/atomvm_rebar3_plugin.app.src
+++ b/src/atomvm_rebar3_plugin.app.src
@@ -19,7 +19,7 @@
 %%
 {application, atomvm_rebar3_plugin, [
     {description, "A rebar plugin for manipulating AtomVM AVM files"},
-    {vsn, "0.7.3"},
+    {vsn, "0.7.4"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, []},


### PR DESCRIPTION
It has been nearly six months since the last release an a number of improvements have been made that should be made available.

This should merge after atomvm/atomvm_packbeam#17.