### PR TITLE
Add port "auto" config - that enables auto detect of port

### DIFF
--- a/src/atomvm_esp32_flash_provider.erl
+++ b/src/atomvm_esp32_flash_provider.erl
@@ -142,10 +142,15 @@ maybe_convert_string(I) ->
 %% @private
 do_flash(ProjectApps, EspTool, Chip, Port, Baud, Offset) ->
     [ProjectAppAVM | _] = [get_avm_file(ProjectApp) || ProjectApp <- ProjectApps],
+    Portparam =
+        case Port of
+            "auto" -> "";
+            _ -> ["--port ", Port]
+        end,
     Cmd = lists:join(" ", [
         EspTool,
         "--chip", Chip,
-        "--port", Port,
+        Portparam,
         "--baud", integer_to_list(Baud),
         "--before", "default_reset",
         "--after", "hard_reset",


### PR DESCRIPTION
similar/equivalent to https://github.com/atomvm/exatomvm/pull/12

Existing behaviour is kept - no defaults changed.

Esptool has auto-detect port features (when --port is left out), where it enumerates serial ports and finds the first port with esp32 connected.

Setting port to "auto" - (in combination with chip auto) - enables huge DX increase - where one can swap devices, and `rebar3 atomvm esp32_flash` - without having to figure out and configure the port.

Also avoids funny stuff like a macbook pro having different name for left/right side usb respectively.