### PR TITLE
Update and expand workflows

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,10 +10,10 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       matrix:
-        otp: ["24", "25", "26"]
+        otp: ["25", "26", "27"]
 
     steps:
     # Setup

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -1,0 +1,35 @@
+#
+#  Copyright 2022 Davide Bettio <davide@uninstall.it>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+name: "Check formatting"
+
+on:
+  push:
+    paths:
+      - '**/*.erl'
+  pull_request:
+    paths:
+      - '**/*.erl'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  erlfmt-check:
+    runs-on: ubuntu-24.04
+    container: erlang:27
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: "Check formatting with Erlang fmt"
+      run: |
+        cd ..
+        git clone --depth 1 -b v1.1.0 https://github.com/WhatsApp/erlfmt.git
+        cd erlfmt
+        rebar3 as release escriptize
+        cd ../atomvm_rebar3_plugin
+        find . -name *.erl | xargs ../erlfmt/_build/release/bin/erlfmt -c

--- a/.github/workflows/reuse-lint.yaml
+++ b/.github/workflows/reuse-lint.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+ Copyright 2022 Fred Dushin <fred@dushin.net>
+
+ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/LGPL-2.1-or-later.txt
+++ b/LICENSES/LGPL-2.1-or-later.txt
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 ## Copyright (c) dushin.net
 ## All rights reserved.
 ##
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+
 
 all: compile etest doc
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+ Copyright 2020-2023 Fred Dushin <fred@dushin.net>
+
+ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
 # atomvm_rebar3_plugin
 
 A [`rebar3`](https://rebar3.org) plugin for simplifying development of Erlang applications targeted for the [AtomVM](http://github.com/atomvm/AtomVM) Erlang abstract machine.

--- a/assets/init_shim.erl
+++ b/assets/init_shim.erl
@@ -1,3 +1,22 @@
+%%
+%% Copyright (c) 2023 Fred Dushin <fred@dushin.net>
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module(init_shim).
 
 -export([start/0]).

--- a/examples/myapp/README.md
+++ b/examples/myapp/README.md
@@ -1,5 +1,10 @@
+<!--
+ Copyright YEAR AUTHOR
+
+ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
 # myapp
 
 Welcome to the myapp AtomVM application.
 
-For informtion about how to build and flash this application, see the [`atomvm_rebar3_plugin`](https://github.com/atomvm/atomvm_rebar3_plugin) Github repository.
+For information about how to build and flash this application, see the [`atomvm_rebar3_plugin`](https://github.com/atomvm/atomvm_rebar3_plugin) Github repository.

--- a/examples/myapp/rebar.config
+++ b/examples/myapp/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/examples/myapp/src/myapp.app.src
+++ b/examples/myapp/src/myapp.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {application, myapp, [
     {description, "An AtomVM application"},

--- a/examples/myapp/src/myapp.erl
+++ b/examples/myapp/src/myapp.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(myapp).
 
 -export([start/0]).

--- a/examples/otp_application/README.md
+++ b/examples/otp_application/README.md
@@ -1,3 +1,9 @@
+<!--
+ Copyright 2023 Fred Dushin <fred@dushin.net>
+
+ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+
 # otp_application
 
 Welcome to the `otp_application` AtomVM application.

--- a/examples/otp_application/rebar.config
+++ b/examples/otp_application/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/examples/otp_application/src/otp_application.app.src
+++ b/examples/otp_application/src/otp_application.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 
 {application, otp_application, [
     {description, "An AtomVM application"},

--- a/examples/otp_application/src/otp_application_app.erl
+++ b/examples/otp_application/src/otp_application_app.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module(otp_application_app).
 
 -export([start/2, stop/1]).

--- a/examples/otp_application/src/otp_application_app.erl
+++ b/examples/otp_application/src/otp_application_app.erl
@@ -22,7 +22,9 @@
 -export([start/2, stop/1]).
 
 start(StartType, StartArgs) ->
-    io:format("Starting otp_application_app with start type ~p and start args ~p ...~n", [StartType, StartArgs]),
+    io:format("Starting otp_application_app with start type ~p and start args ~p ...~n", [
+        StartType, StartArgs
+    ]),
     otp_application_sup:start(StartArgs).
 
 stop(_State) ->

--- a/examples/otp_application/src/otp_application_sup.erl
+++ b/examples/otp_application/src/otp_application_sup.erl
@@ -30,16 +30,16 @@ start(Args) ->
 %%
 
 init(Args) ->
-    {ok, {
-        {one_for_one, 1, 1}, [
-            {
-                otp_application_worker,
-                {otp_application_worker, start_link, [Args]},
-                permanent,
-                brutal_kill,
-                worker,
-                []
-            }
-        ]
-    }
-}.
+    {ok,
+        {
+            {one_for_one, 1, 1}, [
+                {
+                    otp_application_worker,
+                    {otp_application_worker, start_link, [Args]},
+                    permanent,
+                    brutal_kill,
+                    worker,
+                    []
+                }
+            ]
+        }}.

--- a/examples/otp_application/src/otp_application_sup.erl
+++ b/examples/otp_application/src/otp_application_sup.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module(otp_application_sup).
 
 -export([start/1, init/1]).

--- a/examples/otp_application/src/otp_application_worker.erl
+++ b/examples/otp_application/src/otp_application_worker.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module(otp_application_worker).
 
 -export([start_link/1]).

--- a/priv/README.md
+++ b/priv/README.md
@@ -1,3 +1,8 @@
+<!--
+ Copyright {{copyright_year}} <{{author_email}}>
+
+ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
 # {{name}}
 
 Welcome to the {{name}} AtomVM application.

--- a/priv/atomvm_app.template
+++ b/priv/atomvm_app.template
@@ -1,5 +1,5 @@
 %%
-%% Copyright (c) 2020-2023 Fred Dushin <fred@dushin.net>
+%% Copyright (c) {{copyright_year}} <{{author_email}}>
 %% All rights reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,9 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
+%%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %%
 
 {description, "A minimal AtomVM application"}.

--- a/priv/rebar.config
+++ b/priv/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/priv/src/atomvm_app.app.src
+++ b/priv/src/atomvm_app.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 
 {application, {{name}}, [
     {description, "An AtomVM application"},

--- a/priv/src/atomvm_app.erl
+++ b/priv/src/atomvm_app.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module({{name}}).
 
 -export([start/0]).

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,22 @@
+%%
+%% Copyright (c) 2020-2023 Fred Dushin <fred@dushin.net>
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 {erl_opts, [debug_info]}.
 
 {deps, [{atomvm_packbeam, "0.7.2"}]}.

--- a/src/atomvm_bootstrap_provider.erl
+++ b/src/atomvm_bootstrap_provider.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(atomvm_bootstrap_provider).
 
 -behaviour(provider).

--- a/src/atomvm_bootstrap_provider.erl
+++ b/src/atomvm_bootstrap_provider.erl
@@ -65,8 +65,7 @@ init(State) ->
             "This plugin is used internally by the atomvm packbeam task to compile~n"
             "modules that cannot be compiled directly by rebar.~n"
             "~n"
-            "Users typically have no reason to use this task directly.~n"
-        }
+            "Users typically have no reason to use this task directly.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -84,7 +83,11 @@ do(State) ->
         {ok, State}
     catch
         C:E:S ->
-            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
+            rebar_api:error(
+                "An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [
+                    ?PROVIDER, C, E, S
+                ]
+            ),
             {error, E}
     end.
 
@@ -124,7 +127,10 @@ do_bootstrap_app(App, BootstrapDir, Force) ->
     % Dir = rebar_app_info:dir(App),
     case filelib:is_dir(BootstrapDir) of
         true ->
-            BootstrapFiles = [filename:join(BootstrapDir, Mod) || Mod <- filelib:wildcard("*.erl", BootstrapDir)],
+            BootstrapFiles = [
+                filename:join(BootstrapDir, Mod)
+             || Mod <- filelib:wildcard("*.erl", BootstrapDir)
+            ],
             lists:foreach(
                 fun(BootstrapFile) ->
                     do_bootstrap_file(App, BootstrapFile, Force)
@@ -159,17 +165,24 @@ maybe_compile(App, BootstrapFile, EBinDir, Force) ->
     BeamFile = filename:join(EBinDir, Basename ++ ".beam"),
     case Force orelse needs_build(BootstrapFile, BeamFile) of
         true ->
-            CompilerOptions = [{outdir, EBinDir}, report] ++
-                get_compiler_options(App),
-            rebar_api:debug("Compiling bootstrap file ~s with options ~p ...", [BootstrapFile, CompilerOptions]),
-            case compile:file(
+            CompilerOptions =
+                [{outdir, EBinDir}, report] ++
+                    get_compiler_options(App),
+            rebar_api:debug("Compiling bootstrap file ~s with options ~p ...", [
                 BootstrapFile, CompilerOptions
-            ) of
+            ]),
+            case
+                compile:file(
+                    BootstrapFile, CompilerOptions
+                )
+            of
                 {ok, ModuleName} ->
                     rebar_api:debug("Compiled bootstrap module ~p", [ModuleName]),
                     ok;
                 Error ->
-                    rebar_api:error("Failed to compile bootstrap file ~s: ~p", [BootstrapFile, Error]),
+                    rebar_api:error("Failed to compile bootstrap file ~s: ~p", [
+                        BootstrapFile, Error
+                    ]),
                     Error
             end;
         _ ->

--- a/src/atomvm_esp32_flash_provider.erl
+++ b/src/atomvm_esp32_flash_provider.erl
@@ -66,8 +66,7 @@ init(State) ->
         {short_desc, "Flash an AtomVM packbeam to an ESP32 device"},
         {desc,
             "~n"
-            "Use this plugin to flash an AtomVM packbeam file to an ESP32 device.~n"
-        }
+            "Use this plugin to flash an AtomVM packbeam file to an ESP32 device.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -87,7 +86,11 @@ do(State) ->
         {ok, State}
     catch
         C:E:S ->
-            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
+            rebar_api:error(
+                "An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [
+                    ?PROVIDER, C, E, S
+                ]
+            ),
             {error, E}
     end.
 
@@ -152,16 +155,23 @@ do_flash(ProjectApps, EspTool, Chip, Port, Baud, Offset) ->
         end,
     Cmd = lists:join(" ", [
         EspTool,
-        "--chip", Chip,
+        "--chip",
+        Chip,
         Portparam,
-        "--baud", integer_to_list(Baud),
-        "--before", "default_reset",
-        "--after", "hard_reset",
+        "--baud",
+        integer_to_list(Baud),
+        "--before",
+        "default_reset",
+        "--after",
+        "hard_reset",
         "write_flash",
         "-u",
-        "--flash_mode", "keep",
-        "--flash_freq", "keep",
-        "--flash_size", "detect",
+        "--flash_mode",
+        "keep",
+        "--flash_freq",
+        "keep",
+        "--flash_size",
+        "detect",
         Offset,
         ProjectAppAVM
     ]),

--- a/src/atomvm_esp32_flash_provider.erl
+++ b/src/atomvm_esp32_flash_provider.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(atomvm_esp32_flash_provider).
 
 -behaviour(provider).

--- a/src/atomvm_packbeam_provider.erl
+++ b/src/atomvm_packbeam_provider.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(atomvm_packbeam_provider).
 
 -behaviour(provider).

--- a/src/atomvm_packbeam_provider.erl
+++ b/src/atomvm_packbeam_provider.erl
@@ -33,7 +33,8 @@
     {prune, $p, "prune", boolean, "Prune unreferenced BEAM files"},
     {start, $s, "start", atom, "Start module"},
     {application, $a, "application", boolean, "Build a OTP application"},
-    {remove_lines, $r, "remove_lines", boolean, "Remove line information from generated AVM files (off by default)"},
+    {remove_lines, $r, "remove_lines", boolean,
+        "Remove line information from generated AVM files (off by default)"},
     {list, $l, "list", boolean, "List the contents of AVM files after creation"}
 ]).
 
@@ -95,8 +96,7 @@ init(State) ->
         {short_desc, "Create an AtomVM packbeam file"},
         {desc,
             "~n"
-            "Use this plugin to create an AtomVM packbeam file from your rebar3 project.~n"
-        }
+            "Use this plugin to create an AtomVM packbeam file from your rebar3 project.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -119,7 +119,11 @@ do(State) ->
         {ok, State}
     catch
         C:E:S ->
-            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
+            rebar_api:error(
+                "An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [
+                    ?PROVIDER, C, E, S
+                ]
+            ),
             {error, E}
     end.
 
@@ -153,7 +157,10 @@ squash_external_avm({external, AVMPath}, Accum) ->
                 undefined ->
                     [{external_avms, [StrippedPath]} | Accum];
                 OtherAVMs ->
-                    [{external_avms, [StrippedPath | OtherAVMs]} | proplists:delete(external_avms, Accum)]
+                    [
+                        {external_avms, [StrippedPath | OtherAVMs]}
+                        | proplists:delete(external_avms, Accum)
+                    ]
             end;
         _ ->
             throw({enoent, StrippedPath})
@@ -170,18 +177,27 @@ squash_external_avms(ParsedArgs) ->
     ).
 
 %% @private
-do_packbeam(ProjectApps, Deps, ExternalAVMs, Prune, Force, StartModule, IsApplication, IncludeLines, List) ->
+do_packbeam(
+    ProjectApps, Deps, ExternalAVMs, Prune, Force, StartModule, IsApplication, IncludeLines, List
+) ->
     DepFileSets = [get_files(Dep) || Dep <- Deps],
     ProjectAppFileSets = [get_files(ProjectApp) || ProjectApp <- ProjectApps],
     DepsAvms = [
         maybe_create_packbeam(DepFileSet, [], false, Force, undefined, false, IncludeLines, false)
-        || DepFileSet <- DepFileSets
+     || DepFileSet <- DepFileSets
     ],
     [
         maybe_create_packbeam(
-            ProjectAppFileSet, DepsAvms ++ ExternalAVMs, Prune, Force, StartModule, IsApplication, IncludeLines, List
+            ProjectAppFileSet,
+            DepsAvms ++ ExternalAVMs,
+            Prune,
+            Force,
+            StartModule,
+            IsApplication,
+            IncludeLines,
+            List
         )
-        || ProjectAppFileSet <- ProjectAppFileSets
+     || ProjectAppFileSet <- ProjectAppFileSets
     ],
     ok.
 
@@ -191,7 +207,8 @@ get_files(App) ->
     EBinDir = rebar_app_info:ebin_dir(App),
     TestDir = filename:join([rebar_app_info:dir(App), "test"]),
     BootstrapEBinDir = filename:join(OutDir, "bootstrap_ebin"),
-    BeamFiles = get_beam_files(EBinDir) ++ get_beam_files(BootstrapEBinDir) ++ get_beam_files(TestDir),
+    BeamFiles =
+        get_beam_files(EBinDir) ++ get_beam_files(BootstrapEBinDir) ++ get_beam_files(TestDir),
     AppFile = get_app_file(EBinDir),
     PrivFiles = get_all_files(filename:join(OutDir, "priv")),
     Name = binary_to_list(rebar_app_info:name(App)),
@@ -222,7 +239,7 @@ get_app_file(Dir) ->
             undefined;
         [AppFile] ->
             AppFile;
-        [AppFile|_] ->
+        [AppFile | _] ->
             rebar_api:warn("Multiple .app files in ~s (using first): ~p", [Dir, AppFiles]),
             AppFile
     end.
@@ -252,7 +269,9 @@ get_all_files(Dir) ->
     RegularFiles ++ SubFiles.
 
 %% @private
-maybe_create_packbeam(FileSet, AvmFiles, Prune, Force, StartModule, IsApplication, IncludeLines, List) ->
+maybe_create_packbeam(
+    FileSet, AvmFiles, Prune, Force, StartModule, IsApplication, IncludeLines, List
+) ->
     #file_set{
         name = Name,
         out_dir = OutDir,
@@ -262,10 +281,16 @@ maybe_create_packbeam(FileSet, AvmFiles, Prune, Force, StartModule, IsApplicatio
     } = FileSet,
     DirName = filename:dirname(OutDir),
     TargetAVM = filename:join(DirName, Name ++ ".avm"),
-    AppFiles = case AppFile of undefined -> []; _ -> [AppFile] end,
+    AppFiles =
+        case AppFile of
+            undefined -> [];
+            _ -> [AppFile]
+        end,
     case Force orelse needs_build(TargetAVM, BeamFiles ++ PrivFiles ++ AvmFiles ++ AppFiles) of
         true ->
-            create_packbeam(FileSet, AvmFiles, Prune, StartModule, IsApplication, IncludeLines, List);
+            create_packbeam(
+                FileSet, AvmFiles, Prune, StartModule, IsApplication, IncludeLines, List
+            );
         _ ->
             rebar_api:debug("No packbeam build needed.", []),
             TargetAVM
@@ -306,7 +331,8 @@ create_packbeam(FileSet, AvmFiles, Prune, StartModule, IsApplication, IncludeLin
                     init ->
                         rebar_api:warn(
                             "Specifying `init` as the start module to generate an OTP application is deprecated.  "
-                            "Use the `--application` (or `-a`) option, instead.", []
+                            "Use the `--application` (or `-a`) option, instead.",
+                            []
                         ),
                         [create_boot_file(OutDir, ApplicationModule)];
                     _ ->
@@ -318,7 +344,9 @@ create_packbeam(FileSet, AvmFiles, Prune, StartModule, IsApplication, IncludeLin
         DirName = filename:dirname(OutDir),
         ok = file:set_cwd(DirName),
         AvmFilename = Name ++ ".avm",
-        FileList = reorder_beamfiles(BeamFiles) ++ AppFileBinFiles ++ BootFiles ++ PrivFilesRelative ++ AvmFiles,
+        FileList =
+            reorder_beamfiles(BeamFiles) ++ AppFileBinFiles ++ BootFiles ++ PrivFilesRelative ++
+                AvmFiles,
         Opts = #{
             prune => Prune,
             start_module => effective_start_module(StartModule, IsApplication),
@@ -382,9 +410,13 @@ create_app_file_bin_files(AppName, OutDir, AppFile) ->
                     WritePath = filename:join([OutDir, "application.bin"]),
                     Bin = erlang:term_to_binary(ApplicationSpec),
                     ok = file:write_file(WritePath, Bin),
-                    {ApplicationModule, [{WritePath, filename:join([AppName, "priv", "application.bin"])}]};
+                    {ApplicationModule, [
+                        {WritePath, filename:join([AppName, "priv", "application.bin"])}
+                    ]};
                 _ ->
-                    rebar_api:warn("Consulted app file (~s) does not appear to be an app spec.", [AppFile]),
+                    rebar_api:warn("Consulted app file (~s) does not appear to be an app spec.", [
+                        AppFile
+                    ]),
                     {undefined, []}
             end;
         Error ->
@@ -394,7 +426,8 @@ create_app_file_bin_files(AppName, OutDir, AppFile) ->
 
 %% @private
 create_boot_file(OutDir, ApplicationModule) ->
-    Version = {0, 1, 0}, %% TODO
+    %% TODO
+    Version = {0, 1, 0},
     BootSpec = {boot, Version, #{applications => [ApplicationModule]}},
     WritePath = filename:join([OutDir, "start.boot"]),
     Bin = erlang:term_to_binary(BootSpec),

--- a/src/atomvm_pico_flash_provider.erl
+++ b/src/atomvm_pico_flash_provider.erl
@@ -60,8 +60,7 @@ init(State) ->
         {short_desc, "Convert an AtomVM packbeam file to uf2 and copy to an rp2040 device"},
         {desc,
             "~n"
-            "Use this plugin to convert an AtomVM packbeam file to a uf2 file and copy to an rp2040 device.~n"
-        }
+            "Use this plugin to convert an AtomVM packbeam file to a uf2 file and copy to an rp2040 device.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 

--- a/src/atomvm_pico_flash_provider.erl
+++ b/src/atomvm_pico_flash_provider.erl
@@ -17,6 +17,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module(atomvm_pico_flash_provider).
 
 -behaviour(provider).

--- a/src/atomvm_rebar3_plugin.app.src
+++ b/src/atomvm_rebar3_plugin.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 {application, atomvm_rebar3_plugin, [
     {description, "A rebar plugin for manipulating AtomVM AVM files"},
     {vsn, "0.7.3"},

--- a/src/atomvm_rebar3_plugin.erl
+++ b/src/atomvm_rebar3_plugin.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module(atomvm_rebar3_plugin).
 
 -export([init/1]).

--- a/src/atomvm_stm32_flash_provider.erl
+++ b/src/atomvm_stm32_flash_provider.erl
@@ -63,8 +63,7 @@ init(State) ->
         {short_desc, "Flash an AtomVM packbeam file to an STM32 device"},
         {desc,
             "~n"
-            "Use this plugin to flash an AtomVM packbeam file to an STM32 device.~n"
-        }
+            "Use this plugin to flash an AtomVM packbeam file to an STM32 device.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -81,7 +80,11 @@ do(State) ->
         {ok, State}
     catch
         C:E:S ->
-            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
+            rebar_api:error(
+                "An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [
+                    ?PROVIDER, C, E, S
+                ]
+            ),
             {error, E}
     end.
 

--- a/src/atomvm_stm32_flash_provider.erl
+++ b/src/atomvm_stm32_flash_provider.erl
@@ -17,6 +17,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 -module(atomvm_stm32_flash_provider).
 
 -behaviour(provider).

--- a/src/atomvm_uf2create_provider.erl
+++ b/src/atomvm_uf2create_provider.erl
@@ -64,8 +64,7 @@ init(State) ->
         {short_desc, "Create a Raspberry Pico uf2 file from an AtomVM packbeam file"},
         {desc,
             "~n"
-            "Use this plugin to create Raspberry Pico uf2 files from an AtomVM packbeam file.~n"
-        }
+            "Use this plugin to create Raspberry Pico uf2 files from an AtomVM packbeam file.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -84,7 +83,11 @@ do(State) ->
         {ok, State}
     catch
         C:E:S ->
-            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
+            rebar_api:error(
+                "An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [
+                    ?PROVIDER, C, E, S
+                ]
+            ),
             {error, E}
     end.
 

--- a/src/atomvm_version_provider.erl
+++ b/src/atomvm_version_provider.erl
@@ -52,8 +52,7 @@ init(State) ->
         {short_desc, "Print the version of this plugin to the console."},
         {desc,
             "~n"
-            "Use this task to print the version of this plugin to the console.~n"
-        }
+            "Use this task to print the version of this plugin to the console.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -71,7 +70,11 @@ do(State) ->
         {ok, State}
     catch
         C:E:S ->
-            rebar_api:error("An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [?PROVIDER, C, E, S]),
+            rebar_api:error(
+                "An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [
+                    ?PROVIDER, C, E, S
+                ]
+            ),
             {error, E}
     end.
 

--- a/src/atomvm_version_provider.erl
+++ b/src/atomvm_version_provider.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(atomvm_version_provider).
 
 -behaviour(provider).

--- a/src/legacy_esp32_flash_provider.erl
+++ b/src/legacy_esp32_flash_provider.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(legacy_esp32_flash_provider).
 
 -behaviour(provider).

--- a/src/legacy_esp32_flash_provider.erl
+++ b/src/legacy_esp32_flash_provider.erl
@@ -57,8 +57,7 @@ init(State) ->
         {desc,
             "A rebar plugin to flash packbeam files to ESP32 devices.~n~n"
             "IMPORTANT! this plugin has been DEPRECATED!~n"
-            "Use `rebar3 atomvm esp32_flash`, instead.~n"
-        }
+            "Use `rebar3 atomvm esp32_flash`, instead.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 

--- a/src/legacy_packbeam_provider.erl
+++ b/src/legacy_packbeam_provider.erl
@@ -29,8 +29,10 @@
     {external, $e, "external", string, "External AVM modules"},
     {force, $f, "force", boolean, "Force rebuild"},
     {prune, $p, "prune", boolean, "Prune unreferenced BEAM files"},
-    {include_lines, $i, "include_lines", boolean, "Include line information in generated AVM files (DEPRECATED)"},
-    {remove_lines, $r, "remove_lines", boolean, "Remove line information from generated AVM files (off by default)"},
+    {include_lines, $i, "include_lines", boolean,
+        "Include line information in generated AVM files (DEPRECATED)"},
+    {remove_lines, $r, "remove_lines", boolean,
+        "Remove line information from generated AVM files (off by default)"},
     {start, $s, "start", atom, "Start module"}
 ]).
 
@@ -56,8 +58,7 @@ init(State) ->
         {desc,
             "A rebar plugin to create packbeam files.~n~n"
             "IMPORTANT! this plugin has been DEPRECATED!~n"
-            "Use `rebar3 atomvm packbeam`, instead.~n"
-        }
+            "Use `rebar3 atomvm packbeam`, instead.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 

--- a/src/legacy_packbeam_provider.erl
+++ b/src/legacy_packbeam_provider.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(legacy_packbeam_provider).
 
 -behaviour(provider).

--- a/src/legacy_stm32_flash_provider.erl
+++ b/src/legacy_stm32_flash_provider.erl
@@ -55,8 +55,7 @@ init(State) ->
         {desc,
             "A rebar plugin to flash packbeam files to STM32 devices.~n~n"
             "IMPORTANT! this plugin has been DEPRECATED!~n"
-            "Use `rebar3 atomvm stm32_flash`, instead.~n"
-        }
+            "Use `rebar3 atomvm stm32_flash`, instead.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 

--- a/src/legacy_stm32_flash_provider.erl
+++ b/src/legacy_stm32_flash_provider.erl
@@ -17,6 +17,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(legacy_stm32_flash_provider).
 
 -behaviour(provider).

--- a/test/driver/apps/bootstrap/bootstrap/application.erl
+++ b/test/driver/apps/bootstrap/bootstrap/application.erl
@@ -23,7 +23,6 @@
     start/1, stop/1, get_env/2, get_env/3, set_env/3, set_env/4, ensure_all_started/1
 ]).
 
-
 start(Application) ->
     avm_application_controller:start_application(Application).
 

--- a/test/driver/apps/bootstrap/rebar.config
+++ b/test/driver/apps/bootstrap/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/test/driver/apps/bootstrap/src/myapp.app.src
+++ b/test/driver/apps/bootstrap/src/myapp.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {application, myapp, [
     {description, "An AtomVM application"},

--- a/test/driver/apps/bootstrap/src/myapp.erl
+++ b/test/driver/apps/bootstrap/src/myapp.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(myapp).
 
 -export([start/0]).

--- a/test/driver/apps/bootstrap/src/start.erl
+++ b/test/driver/apps/bootstrap/src/start.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(start).
 
 -export([start/0]).

--- a/test/driver/apps/multi-start/rebar.config
+++ b/test/driver/apps/multi-start/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/test/driver/apps/multi-start/src/myapp.app.src
+++ b/test/driver/apps/multi-start/src/myapp.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {application, myapp, [
     {description, "An AtomVM application"},

--- a/test/driver/apps/multi-start/src/myapp.erl
+++ b/test/driver/apps/multi-start/src/myapp.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(myapp).
 
 -export([start/0]).

--- a/test/driver/apps/multi-start/src/start.erl
+++ b/test/driver/apps/multi-start/src/start.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(start).
 
 -export([start/0]).

--- a/test/driver/apps/myapp/rebar.config
+++ b/test/driver/apps/myapp/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/test/driver/apps/myapp/src/myapp.app.src
+++ b/test/driver/apps/myapp/src/myapp.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {application, myapp, [
     {description, "An AtomVM application"},

--- a/test/driver/apps/myapp/src/myapp.erl
+++ b/test/driver/apps/myapp/src/myapp.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(myapp).
 
 -export([start/0]).

--- a/test/driver/apps/otp_application/rebar.config
+++ b/test/driver/apps/otp_application/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/test/driver/apps/otp_application/src/my_app.app.src
+++ b/test/driver/apps/otp_application/src/my_app.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {application, my_app, [
     {description, "An AtomVM application"},

--- a/test/driver/apps/otp_application/src/my_app.erl
+++ b/test/driver/apps/otp_application/src/my_app.erl
@@ -14,6 +14,10 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
 -module(my_app).
 
 -export([start/2, stop/1]).

--- a/test/driver/apps/prune/rebar.config
+++ b/test/driver/apps/prune/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/test/driver/apps/prune/src/a.erl
+++ b/test/driver/apps/prune/src/a.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(a).
 
 -export([do/0]).

--- a/test/driver/apps/prune/src/b.erl
+++ b/test/driver/apps/prune/src/b.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(b).
 
 -export([do/1]).

--- a/test/driver/apps/prune/src/c.erl
+++ b/test/driver/apps/prune/src/c.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(c).
 
 -export([do/0]).

--- a/test/driver/apps/prune/src/d.erl
+++ b/test/driver/apps/prune/src/d.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(d).
 
 -export([do/0]).

--- a/test/driver/apps/prune/src/myapp.app.src
+++ b/test/driver/apps/prune/src/myapp.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {application, myapp, [
     {description, "An AtomVM application"},

--- a/test/driver/apps/prune/src/myapp.erl
+++ b/test/driver/apps/prune/src/myapp.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(myapp).
 
 -export([start/0]).

--- a/test/driver/apps/rebar_overrides/rebar.config
+++ b/test/driver/apps/rebar_overrides/rebar.config
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {erl_opts, [debug_info]}.
 {deps, []}.

--- a/test/driver/apps/rebar_overrides/src/myapp.app.src
+++ b/test/driver/apps/rebar_overrides/src/myapp.app.src
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 
 {application, myapp, [
     {description, "An AtomVM application"},

--- a/test/driver/apps/rebar_overrides/src/myapp.erl
+++ b/test/driver/apps/rebar_overrides/src/myapp.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(myapp).
 
 -export([start/0]).

--- a/test/driver/apps/rebar_overrides/src/start.erl
+++ b/test/driver/apps/rebar_overrides/src/start.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(start).
 
 -export([start/0]).

--- a/test/driver/rebar.config
+++ b/test/driver/rebar.config
@@ -1,3 +1,22 @@
+%%
+%% Copyright (c) 2023 Fred Dushin <fred@dushin.net>
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%%
 {erl_opts, [no_debug_info]}.
 {deps, [atomvm_packbeam]}.
 

--- a/test/driver/scripts/clean.sh
+++ b/test/driver/scripts/clean.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+##
+## Copyright (c) dushin.net
+## All rights reserved.
+##
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 
 root_dir="$(cd $(dirname $0)/.. && pwd)"
 apps_dir="${root_dir}/apps"

--- a/test/driver/scripts/prepare.sh
+++ b/test/driver/scripts/prepare.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+##
+## Copyright (c) dushin.net
+## All rights reserved.
+##
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 
 root_dir="$(cd $(dirname $0)/.. && pwd)"
 apps_dir="${root_dir}/apps"

--- a/test/driver/src/bootstrap_tests.erl
+++ b/test/driver/src/bootstrap_tests.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(bootstrap_tests).
 
 -export([run/1]).

--- a/test/driver/src/bootstrap_tests.erl
+++ b/test/driver/src/bootstrap_tests.erl
@@ -28,7 +28,6 @@ run(Opts) ->
 
 %% @private
 test_bootstrap_task(Opts) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "bootstrap"]),
 
@@ -36,14 +35,14 @@ test_bootstrap_task(Opts) ->
     Output = test:execute_cmd(Cmd, Opts),
     test:debug(Output, Opts),
 
-    AppblicationBeamPath = test:make_path([AppDir, "_build/default/lib/myapp/bootstrap_ebin/application.beam"]),
+    AppblicationBeamPath = test:make_path([
+        AppDir, "_build/default/lib/myapp/bootstrap_ebin/application.beam"
+    ]),
     ok = test:file_exists(AppblicationBeamPath),
 
     test:tick().
 
-
 test_packbeam_with_bootstrap(Opts) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "bootstrap"]),
 

--- a/test/driver/src/driver.app.src
+++ b/test/driver/src/driver.app.src
@@ -1,3 +1,22 @@
+%%
+%% Copyright (c) 2023 <fred@dushin.net>
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, driver,
  [{description, "An escript"},
   {vsn, "0.1.0"},

--- a/test/driver/src/driver.erl
+++ b/test/driver/src/driver.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(driver).
 
 -export([main/1]).

--- a/test/driver/src/esp32_flash_tests.erl
+++ b/test/driver/src/esp32_flash_tests.erl
@@ -29,7 +29,6 @@ run(Opts) ->
 
 %% @private
 test_flags(Opts) ->
-
     test_flags(Opts, [], [
         {"--chip", "auto"},
         {"--port", "/dev/ttyUSB0"},
@@ -37,21 +36,24 @@ test_flags(Opts) ->
         {"--offset", "0x210000"}
     ]),
 
-    test_flags(Opts, [
+    test_flags(
+        Opts,
+        [
             {"-c", "esp32c3"},
             {"-p", "/dev/tty.usbserial-0001"}
-        ], [
+        ],
+        [
             {"--chip", "esp32c3"},
             {"--port", "tty.usbserial-0001"},
             {"--baud", "115200"},
             {"--offset", "0x210000"}
-    ]),
+        ]
+    ),
 
     ok.
 
 %% @private
 test_flags(Opts, Flags, FlagExpectList) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "myapp"]),
 
@@ -71,7 +73,9 @@ test_flags(Opts, Flags, FlagExpectList) ->
 
 %% @private
 test_env_overrides(Opts) ->
-    test_env_overrides(Opts, "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_PORT", "/dev/tty.usbserial-0001", "--port"),
+    test_env_overrides(
+        Opts, "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_PORT", "/dev/tty.usbserial-0001", "--port"
+    ),
     test_env_overrides(Opts, "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_CHIP", "esp32", "--chip"),
     test_env_overrides(Opts, "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_BAUD", "921600", "--baud"),
     test_env_overrides(Opts, "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_OFFSET", "0x1000", ""),
@@ -79,7 +83,6 @@ test_env_overrides(Opts) ->
 
 %% @private
 test_env_overrides(Opts, EnvVar, Value, Flag) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "myapp"]),
 
@@ -94,13 +97,21 @@ test_env_overrides(Opts, EnvVar, Value, Flag) ->
 %% @private
 test_rebar_overrides(Opts) ->
     %% the rebar_overrides rebar.config specifies tge esp32c3 chip
-    test_rebar_overrides(Opts, [], "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_CHIP", "esp32", "--chip", "esp32c3"),
-    test_rebar_overrides(Opts, [{"-c", "esp32h2"}], "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_CHIP", "esp32", "--chip", "esp32h2"),
+    test_rebar_overrides(
+        Opts, [], "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_CHIP", "esp32", "--chip", "esp32c3"
+    ),
+    test_rebar_overrides(
+        Opts,
+        [{"-c", "esp32h2"}],
+        "ATOMVM_REBAR3_PLUGIN_ESP32_FLASH_CHIP",
+        "esp32",
+        "--chip",
+        "esp32h2"
+    ),
     ok.
 
 %% @private
 test_rebar_overrides(Opts, Flags, EnvVar, Value, Flag, ExpectedValue) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "rebar_overrides"]),
 

--- a/test/driver/src/esp32_flash_tests.erl
+++ b/test/driver/src/esp32_flash_tests.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(esp32_flash_tests).
 
 -export([run/1]).

--- a/test/driver/src/packbeam_tests.erl
+++ b/test/driver/src/packbeam_tests.erl
@@ -31,11 +31,11 @@ run(Opts) ->
 
 %% @private
 test_defaults(Opts) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "myapp"]),
 
-    Cmd = create_packbeam_cmd(AppDir, ["-f"], []), %% -f temporary during dev
+    %% -f temporary during dev
+    Cmd = create_packbeam_cmd(AppDir, ["-f"], []),
     Output = test:execute_cmd(Cmd, Opts),
     test:debug(Output, Opts),
 
@@ -58,11 +58,11 @@ test_defaults(Opts) ->
 
 %% @private
 test_start(Opts) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "multi-start"]),
 
-    Cmd = create_packbeam_cmd(AppDir, ["-f"], []), %% -f temporary during dev
+    %% -f temporary during dev
+    Cmd = create_packbeam_cmd(AppDir, ["-f"], []),
     Output = test:execute_cmd(Cmd, Opts),
     test:debug(Output, Opts),
 
@@ -99,11 +99,11 @@ test_start(Opts) ->
 
 %% @private
 test_prune(Opts) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "prune"]),
 
-    Cmd = create_packbeam_cmd(AppDir, ["-f"], []), %% -f temporary during dev
+    %% -f temporary during dev
+    Cmd = create_packbeam_cmd(AppDir, ["-f"], []),
     Output = test:execute_cmd(Cmd, Opts),
     test:debug(Output, Opts),
 
@@ -143,11 +143,11 @@ test_prune(Opts) ->
 
 %% @private
 test_rebar_overrides(Opts) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "rebar_overrides"]),
 
-    Cmd = create_packbeam_cmd(AppDir, ["-f"], []), %% -f temporary during dev
+    %% -f temporary during dev
+    Cmd = create_packbeam_cmd(AppDir, ["-f"], []),
     Output = test:execute_cmd(Cmd, Opts),
     test:debug(Output, Opts),
 
@@ -184,11 +184,11 @@ test_rebar_overrides(Opts) ->
 
 %% @private
 test_otp_application(Opts) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "otp_application"]),
 
-    Cmd = create_packbeam_cmd(AppDir, ["-f"], []), %% -f temporary during dev
+    %% -f temporary during dev
+    Cmd = create_packbeam_cmd(AppDir, ["-f"], []),
     Output = test:execute_cmd(Cmd, Opts),
     test:debug(Output, Opts),
 
@@ -209,7 +209,9 @@ test_otp_application(Opts) ->
     true = packbeam_api:is_beam(MyAppBeam),
     false = packbeam_api:is_entrypoint(MyAppBeam),
 
-    {value, MyAppApplicationBin} = test:find_avm_element_by_name("my_app/priv/application.bin", AVMElements),
+    {value, MyAppApplicationBin} = test:find_avm_element_by_name(
+        "my_app/priv/application.bin", AVMElements
+    ),
     false = packbeam_api:is_beam(MyAppApplicationBin),
     false = packbeam_api:is_entrypoint(MyAppApplicationBin),
 

--- a/test/driver/src/packbeam_tests.erl
+++ b/test/driver/src/packbeam_tests.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(packbeam_tests).
 
 -export([run/1]).

--- a/test/driver/src/stm32_flash_tests.erl
+++ b/test/driver/src/stm32_flash_tests.erl
@@ -29,22 +29,24 @@ run(Opts) ->
 
 %% @private
 test_flags(Opts) ->
-
     test_flags(Opts, [], [
         {"", "0x8080000"}
     ]),
 
-    test_flags(Opts, [
+    test_flags(
+        Opts,
+        [
             {"-o", "0x1234"}
-        ], [
+        ],
+        [
             {"", "0x1234"}
-    ]),
+        ]
+    ),
 
     ok.
 
 %% @private
 test_flags(Opts, Flags, FlagExpectList) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "myapp"]),
 
@@ -69,7 +71,6 @@ test_env_overrides(Opts) ->
 
 %% @private
 test_env_overrides(Opts, EnvVar, Value, Flag) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "myapp"]),
 
@@ -84,12 +85,13 @@ test_env_overrides(Opts, EnvVar, Value, Flag) ->
 %% @private
 test_rebar_overrides(Opts) ->
     %% the rebar_overrides rebar.config specifies a 0x1234 offset
-    test_rebar_overrides(Opts, [], "ATOMVM_REBAR3_PLUGIN_STM32_FLASH_OFFSET", "0x54321", "", "0x1234"),
+    test_rebar_overrides(
+        Opts, [], "ATOMVM_REBAR3_PLUGIN_STM32_FLASH_OFFSET", "0x54321", "", "0x1234"
+    ),
     ok.
 
 %% @private
 test_rebar_overrides(Opts, Flags, EnvVar, Value, Flag, ExpectedValue) ->
-
     AppsDir = maps:get(apps_dir, Opts),
     AppDir = test:make_path([AppsDir, "rebar_overrides"]),
 

--- a/test/driver/src/stm32_flash_tests.erl
+++ b/test/driver/src/stm32_flash_tests.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(stm32_flash_tests).
 
 -export([run/1]).

--- a/test/driver/src/test.erl
+++ b/test/driver/src/test.erl
@@ -51,7 +51,6 @@ prepare_tests() ->
 
 %% @private
 run_tests(Opts) ->
-
     io:put_chars("packbeam_tests: "),
     ok = packbeam_tests:run(Opts),
     io:put_chars("\n"),
@@ -110,18 +109,19 @@ make_env(Env) ->
         end,
         [],
         Env
-     ).
+    ).
 
 make_opts(Opts) ->
     lists:foldl(
-        fun({Key, Value}, Accum) ->
-            io_lib:format("~s ~s ", [Key, Value]) ++ Accum;
-           (Key, Accum) ->
-            io_lib:format("~s ", [Key]) ++ Accum
+        fun
+            ({Key, Value}, Accum) ->
+                io_lib:format("~s ~s ", [Key, Value]) ++ Accum;
+            (Key, Accum) ->
+                io_lib:format("~s ", [Key]) ++ Accum
         end,
         [],
         Opts
-     ).
+    ).
 
 execute_cmd(Cmd) ->
     execute_cmd(Cmd, false).

--- a/test/driver/src/test.erl
+++ b/test/driver/src/test.erl
@@ -14,6 +14,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 -module(test).
 
 -export([run/1]).

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+##
+## Copyright (c) dushin.net
+## All rights reserved.
+##
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 
 set -e
 


### PR DESCRIPTION
Updates the `build-and-test` workflow to run on `ubuntu-22.04` and adds OTP 27 to the test matrix.
Formatting has been fixed on all files according to `erlfmt -c`, and a modified version of the AtomVM check-formatting workflow has been adapted to only check Erlang formatting.
Missing license information has been added, along with a modified version of the AtomVM `reuse-lint` workflow.