### PR TITLE
Allow relative path for `--external` AVMs in packbeam task

### DIFF
--- a/src/atomvm_packbeam_provider.erl
+++ b/src/atomvm_packbeam_provider.erl
@@ -150,7 +150,7 @@ get_opts(State) ->
 
 %% @private
 squash_external_avm({external, AVMPath}, Accum) ->
-    StrippedPath = string:strip(AVMPath, both),
+    StrippedPath = filename:absname(string:strip(AVMPath, both)),
     case filelib:is_file(StrippedPath) of
         true ->
             case proplists:get_value(external_avms, Accum) of


### PR DESCRIPTION
Changes the way external AVMs are parsed to allow using a relative path to the included `.avm` files.

Closes #29