### PR TITLE
Update defaut ESP32 flash offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.4] (unreleased)
 
+### Added
+
 - Added support for the `--application` (or `-a`) option to support AtomVM OTP applications.
 
 ### Changed
 
 - Using the `-s init` option is still supported but deprecated.  Use the `--application` (or `-a`) option to generate OTP applications using AtomVM.
 - Replace `atomvm_uf2create_provider` uf2 creation code with [upstream `uf2tool`](https://github.com/pguyot/uf2tool)
+- Updated default offset for esp32 devices to match new offset (for unrelesed AtomVM release-0.7)
 
 ## [0.7.3] (2023.11.25)
 

--- a/src/atomvm_esp32_flash_provider.erl
+++ b/src/atomvm_esp32_flash_provider.erl
@@ -32,7 +32,7 @@
     {chip, $c, "chip", string, "ESP chip (default auto)"},
     {port, $p, "port", string, "Device port (default /dev/ttyUSB0)"},
     {baud, $b, "baud", integer, "Baud rate (default 115200)"},
-    {offset, $o, "offset", string, "Offset (default 0x210000)"}
+    {offset, $o, "offset", string, "Offset (default 0x2D0000)"}
 ]).
 
 -define(DEFAULT_OPTS, #{
@@ -40,7 +40,7 @@
     chip => "auto",
     port => "/dev/ttyUSB0",
     baud => 115200,
-    offset => "0x210000"
+    offset => "0x2D0000"
 }).
 
 %%


### PR DESCRIPTION
Update the `atomvm esp32_flash` task to use the new offset of `0x2D0000` as the default.