### PR TITLE
Change uf2tool dependency to hex.pm

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
 
 {deps, [
     {atomvm_packbeam, "0.7.4"},
-    {uf2tool, {git, "https://github.com/pguyot/uf2tool.git", {tag, "v1.1.0"}}}
+    {uf2tool, "1.1.0"}
 ]}.
 
 {ex_doc, [


### PR DESCRIPTION
Changes the rebar.conf depencency for `uf2tool` to download from hex.pm instead of a GitHub tag. This will allow dependancies to show up on the hex.pm package info page.