### PR TITLE
Fix workflow for OTP 25

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,6 +15,16 @@ jobs:
       matrix:
         otp: ["25", "26", "27", "28"]
 
+        include:
+          - otp: "25"
+            make_jobs: "compile etest"
+          - otp: "26"
+            make_jobs: "all"
+          - otp: "27"
+            make_jobs: "all"
+          - otp: "28"
+            make_jobs: "all"
+
     steps:
     # Setup
     - name: "Checkout repo"
@@ -47,4 +57,4 @@ jobs:
 
     # Build
     - name: "Make"
-      run: PATH="/tmp/rebar3:${PATH}" make all
+      run: PATH="/tmp/rebar3:${PATH}" make ${{ matrix.make_jobs }}


### PR DESCRIPTION
The rebar3 plugin ex_doc is not available for OTP releases prior to OTP 26. This fixes the matrix test for OTP 25 by skipping the `make doc` job and only executing the `compile` and `etest` jobs.