### PR TITLE
Fix bugs in dialyzer task

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,14 +524,22 @@ Use the `dialyzer` task to check applications for type discrepancies. To use the
 $ rebar3 atomvm dialyzer
 ```
 
-This task requires a complete AtomVM installation. This includes the AtomVM binary, the standard atomvmlib libraries, compiled beam files, and the `atomvm`
-launcher script. The `atomvm` launcher script should be in your PATH. This is all taken care of with a MacOS install using MacPorts, or Homebrew.
-Linux users will need to build from source and use the cmake "install" target. If you have "installed" AtomVM to a non-standard location (i.e. /otp/atomvm)
-and the `atomvm` launcher script is not in your PATH you must supply the install location containing the AtomVM libraries using the `--atomvm_root` option
-when using this task. For example:
+The `atomvm` launcher script should be in your PATH. This is taken care of with a MacOS install using MacPorts, or
+Homebrew. Linux users will need to build from source and use the cmake "install" target. If you have installed AtomVM
+to a non-standard location (i.e. /otp/atomvm) and the `atomvm` launcher script is not in your PATH you must supply the
+install location containing the AtomVM libraries using the `--atomvm_root` option when using this task. You may also
+use the path to the build directory used for a generic_unix build of the AtomVM BEAM libraries.
+
+Example for a non-standard instal when `atomvm` launcher is not in PATH:
 
 ```
 $ rebar3 atomvm dialyzer --atomvm_root /opt/atomvm
+```
+
+Example using a development build directory:
+
+```
+$ rebar3 atomvm dialyzer --atomvm_root /home/joe/work/AtomVM/build
 ```
 
 This option may also be supplied in the `atomvm_rebar3_plugin` configuration options in rebar.conf. Example:

--- a/src/atomvm_dialyzer_provider.erl
+++ b/src/atomvm_dialyzer_provider.erl
@@ -72,9 +72,6 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    % no plugins in analysis
-    rebar_paths:unset_paths([plugins], State),
-    rebar_paths:set_paths([deps], State),
     try
         Config = get_opts(State),
         rebar_api:debug("Effective opts for ~p: ~p", [?PROVIDER, Config]),

--- a/src/atomvm_dialyzer_provider.erl
+++ b/src/atomvm_dialyzer_provider.erl
@@ -180,7 +180,7 @@ base_plt_absname(Config) ->
                 string:trim(Path)
         end,
     Base = maps:get(base_plt_location, Config, filename:join(Home, ".cache/rebar3")),
-    [Version, _] = string:split(string:trim(os:cmd("atomvm -version")), "+"),
+    Version = string:trim(os:cmd("atomvm -version")),
     BasePLT = filename:absname_join(filename:absname(Base), "AtomVM-" ++ Version ++ ".plt"),
     rebar_api:debug("Base PLT file: ~p", [BasePLT]),
     string:trim(BasePLT).

--- a/src/atomvm_dialyzer_provider.erl
+++ b/src/atomvm_dialyzer_provider.erl
@@ -155,10 +155,9 @@ do_dialize(Config, State) ->
 check_base_plt(Config) ->
     rebar_api:info("Checking AtomVM base PLT...", []),
     PLT = base_plt_absname(Config),
-    BEAMdir = get_base_beam_path(Config),
     try
         dialyzer:run([
-            {analysis_type, plt_check}, {plts, [PLT]}, {output_plt, PLT}, {files_rec, BEAMdir}
+            {analysis_type, plt_check}, {init_plt, PLT}, {output_plt, PLT}
         ])
     of
         [] ->


### PR DESCRIPTION
Fixes several bugs in the atomvm dialyzer task. Beam paths are correctly discovered when using the AtomVM/build directory as the atomvm_root. A bug which caused the plt check to always fail, causing a complete rebuild was fixed. The full atomvm version is used in the base PLT name so PLTs from different branches can be used without loosing the previous ones. The task will now abort when an error occurs rather than try to keep going. Improved error messages, stack traces are only printed (with better formatting) when running rebar3 with DEBUG=1.