### PR TITLE
Updates and enhancements for RP2 platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added dialyzer task to simplify running dialyzer on AtomVM applications.
 
+### Changed
+- The `uf2create` task now creates `universal` format uf2 files by default, suitable for both
+rp2040 or rp2350 devices.
+
 ## [0.7.5] (2025.05.27)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added dialyzer task to simplify running dialyzer on AtomVM applications.
 - Added support for rp2350 devices to allow for default detection of the device mount path.
+- Added configuration paramenter for setting the path to picotool for the pico_flash task.
 
 ### Changed
 - The `uf2create` task now creates `universal` format uf2 files by default, suitable for both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 rp2040 or rp2350 devices.
 - The `pico_flash` task now checks that a device is an RP2 platform before resetting to `BOOTSEL`
 mode, preventing interference with other MCUs that may be attached to the host system.
+- The `pico_flash` task now aborts on all errors rather than trying to continue after a failure.
 
 ## [0.7.5] (2025.05.27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added dialyzer task to simplify running dialyzer on AtomVM applications.
+- Added support for rp2350 devices to allow for default detection of the device mount path.
 
 ### Changed
 - The `uf2create` task now creates `universal` format uf2 files by default, suitable for both
 rp2040 or rp2350 devices.
+- The `pico_flash` task now checks that a device is an RP2 platform before resetting to `BOOTSEL`
+mode, preventing interference with other MCUs that may be attached to the host system.
 
 ## [0.7.5] (2025.05.27)
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ The following table enumerates the properties that may be defined in your projec
 |-----|------|-------------|
 | `path` | `string()` | Path to pico device |
 | `reset` | `string()` | Path to serial device to reset before flashing |
+| `picotool` | `string()` | Path to picotool executable |
 
 Example:
 
@@ -458,6 +459,7 @@ Alternatively, the following environment variables may be used to control the ab
 
 * `ATOMVM_REBAR3_PLUGIN_PICO_MOUNT_PATH` | `ATOMVM_PICO_MOUNT_PATH`
 * `ATOMVM_REBAR3_PLUGIN_PICO_RESET_DEV` | `ATOMVM_PICO_RESET_DEV`
+* `ATOMVM_REBAR3_PLUGIN_PICOTOOL` | `ATOMVM_PICOTOOL`
 
 Any setting specified on the command line take precedence over entries in `rebar.config`, which in turn take precedence over environment variable settings, which in turn take precedence over the default values specified above.
 

--- a/src/atomvm_pico_flash_provider.erl
+++ b/src/atomvm_pico_flash_provider.erl
@@ -79,8 +79,7 @@ do(State) ->
         {ok, State}
     catch
         _C:E:_S ->
-            rebar_api:error("An error occurred in the ~p task.  Error=~p~n", [?PROVIDER, E]),
-            {error, E}
+            rebar_api:abort("An error occurred in the ~p task.  Error=~p~n", [?PROVIDER, E])
     end.
 
 -spec format_error(any()) -> iolist().
@@ -278,8 +277,7 @@ do_reset(ResetPort, Picotool) ->
                         "The device was asked to reboot into BOOTSEL mode." ->
                             ok;
                         BootError ->
-                            rebar_api:error("Failed to prepare pico for flashing: ~s", [BootError]),
-                            erlang:throw(picoflash_reboot_error)
+                            rebar_api:abort("Failed to prepare pico for flashing: ~s", [BootError])
                     end
             end
     end.
@@ -319,8 +317,7 @@ do_flash(ProjectApps, PicoPath, ResetDev, Picotool) ->
         {ok, _Size} ->
             ok;
         CopyError ->
-            rebar_api:error("Failed to copy application file ~s to pico: ~s", [File, CopyError]),
-            erlang:throw(picoflash_copy_error)
+            rebar_api:abort("Failed to copy application file ~s to pico: ~s", [File, CopyError])
     end,
     rebar_api:info("Successfully loaded ~s application to the device.", [App]),
     ok.

--- a/src/atomvm_pico_flash_provider.erl
+++ b/src/atomvm_pico_flash_provider.erl
@@ -104,11 +104,11 @@ env_opts() ->
     #{
         path => os:getenv(
             "ATOMVM_REBAR3_PLUGIN_PICO_MOUNT_PATH",
-            get_default_mount()
+            os:getenv("ATOMVM_PICO_MOUNT_PATH", "")
         ),
         reset => os:getenv(
             "ATOMVM_REBAR3_PLUGIN_PICO_RESET_DEV",
-            get_reset_base()
+            get_reset_dev()
         )
     }.
 
@@ -123,77 +123,102 @@ get_stty_file_flag() ->
     end.
 
 %% @private
-get_reset_base() ->
+get_reset_dev() ->
     {_Fam, System} = os:type(),
     Base =
         case System of
             linux ->
-                "/dev/ttyACM*";
+                filelib:wildcard("/dev/serial/by-id/usb-Raspberry_Pi_Pico_????????????????-if00");
             darwin ->
-                "/dev/cu.usbmodem14*";
+                Bin = darwin_ioreg:pico_callout_devices(),
+                lists:foldl(fun(Path, Acc) -> [binary_to_list(Path) | Acc] end, [], Bin);
             _Other ->
-                ""
+                []
         end,
     os:getenv("ATOMVM_PICO_RESET_DEV", Base).
 
-%% @private
-get_default_mount() ->
+%%% @private
+find_mounted_pico() ->
     {_Fam, System} = os:type(),
-    Default =
+    Wildcard =
         case System of
             linux ->
-                "/run/media/" ++ os:getenv("USER") ++ "/RPI-RP2";
+                "/run/media/" ++ os:getenv("USER") ++ "/{RPI-RP2,RP2350}";
             darwin ->
-                "/Volumes/RPI-RP2";
+                "/Volumes/{RPI-RP2,RP2350}";
             _Other ->
                 ""
         end,
-    os:getenv("ATOMVM_PICO_MOUNT_PATH", Default).
-
-%% @private
-wait_for_mount(Mount, Count) when Count < 30 ->
-    try
-        case file:read_link_info(Mount) of
-            {ok, #file_info{type = directory} = _Info} ->
-                ok;
-            _ ->
-                timer:sleep(1000),
-                wait_for_mount(Mount, Count + 1)
-        end
-    catch
+    case filelib:wildcard(Wildcard) of
+        [Pico | _] = Path ->
+            rebar_api:debug("Found pico device, using ~p from devices list: ~p", [Pico, Path]),
+            {ok, Pico};
         _ ->
-            timer:sleep(1000),
-            wait_for_mount(Mount, Count + 1)
-    end;
-wait_for_mount(Mount, 30) ->
-    rebar_api:error("Pico not mounted at ~s after 30 seconds. giving up...", [Mount]),
-    erlang:throw(mount_error).
-
-%% @private
-check_pico_mount(Mount) ->
-    try
-        case file:read_link_info(Mount) of
-            {ok, #file_info{type = directory} = _Info} ->
-                rebar_api:debug("Pico mounted at ~s.", [Mount]),
-                ok;
-            _ ->
-                rebar_api:error("Pico not mounted at ~s.", [Mount]),
-                erlang:throw(no_device)
-        end
-    catch
-        _ ->
-            rebar_api:error("Pico not mounted at ~s.", [Mount]),
-            erlang:throw(no_device)
+            not_found
     end.
 
 %% @private
-needs_reset(ResetBase) ->
-    case filelib:wildcard(ResetBase) of
+wait_for_mount(Mount, Count) when Count < 30 ->
+    case Mount of
+        "" ->
+            case find_mounted_pico() of
+                not_found ->
+                    timer:sleep(1000),
+                    wait_for_mount(Mount, Count + 1);
+                {ok, Pico} ->
+                    case file:read_link_info(Pico) of
+                        {ok, #file_info{type = directory} = _Info} ->
+                            {ok, Pico};
+                        Err ->
+                            rebar_api:abort("Pico mount point is not a directory (~p)", [Err])
+                    end
+            end;
+        Path ->
+            case file:read_link_info(Path) of
+                {ok, #file_info{type = directory} = _Info} ->
+                    {ok, Path};
+                _ ->
+                    timer:sleep(1000),
+                    wait_for_mount(Mount, Count + 1)
+            end
+    end;
+wait_for_mount(_Mount, 30) ->
+    rebar_api:abort("Pico not mounted after 30 seconds. giving up...", []).
+
+%% @private
+get_pico_mount(Mount) ->
+    case Mount of
+        "" ->
+            case find_mounted_pico() of
+                not_found ->
+                    rebar_api:info("Waiting for an RP2 device to mount...", []),
+                    wait_for_mount(Mount, 0);
+                {ok, Pico} ->
+                    {ok, Pico}
+            end;
+        Path ->
+            case file:read_link_info(Path) of
+                {ok, #file_info{type = directory} = _Info} ->
+                    rebar_api:debug("Pico mounted at ~s.", [Mount]),
+                    {ok, Path};
+                _ ->
+                    rebar_api:info("Waiting for the device at path ~s to mount...", [
+                        string:trim(Mount)
+                    ]),
+                    wait_for_mount(Mount, 0)
+            end
+    end.
+
+%% @private
+needs_reset(ResetDev) ->
+    case ResetDev of
         [] ->
             false;
         [ResetPort | _T] ->
             case file:read_link_info(ResetPort) of
                 {ok, #file_info{type = device} = _Info} ->
+                    {true, ResetPort};
+                {ok, #file_info{type = symlink} = _Info} ->
                     {true, ResetPort};
                 _ ->
                     false
@@ -208,7 +233,7 @@ do_reset(ResetPort) ->
     BootselMode = lists:join(" ", [
         "stty", Flag, ResetPort, "1200"
     ]),
-    rebar_api:debug("Resetting device at path ~s", [ResetPort]),
+    rebar_api:info("Resetting device at path ~s", [ResetPort]),
     ResetStatus = os:cmd(BootselMode),
     case ResetStatus of
         "" ->
@@ -259,25 +284,23 @@ get_uf2_appname(ProjectApps) ->
     binary_to_list(rebar_app_info:name(App)).
 
 %% @private
-do_flash(ProjectApps, PicoPath, ResetBase) ->
-    case needs_reset(ResetBase) of
+do_flash(ProjectApps, PicoPath, ResetDev) ->
+    case needs_reset(ResetDev) of
         false ->
-            rebar_api:debug("No Pico found matching ~s.", [ResetBase]),
+            rebar_api:debug("No Pico reset device found matching ~s.", [ResetDev]),
             ok;
         {true, ResetPort} ->
             rebar_api:debug("Pico at ~s needs reset...", [ResetPort]),
             do_reset(ResetPort),
-            rebar_api:info("Waiting for the device at path ~s to settle and mount...", [
-                string:trim(PicoPath)
-            ]),
+            rebar_api:info("Waiting for the device at path ~s to settle and mount...", [PicoPath]),
             wait_for_mount(PicoPath, 0)
     end,
-    check_pico_mount(PicoPath),
+    {ok, Path} = get_pico_mount(PicoPath),
     TargetUF2 = get_uf2_file(ProjectApps),
     App = get_uf2_appname(ProjectApps),
     File = App ++ ".uf2",
-    Dest = filename:join(PicoPath, File),
-    rebar_api:info("Copying ~s", [File]),
+    Dest = filename:join(Path, File),
+    rebar_api:info("Copying ~s to ~s", [File, Path]),
     case file:copy(TargetUF2, Dest) of
         {ok, _Size} ->
             ok;
@@ -285,5 +308,5 @@ do_flash(ProjectApps, PicoPath, ResetBase) ->
             rebar_api:error("Failed to copy application file ~s to pico: ~s", [File, CopyError]),
             erlang:throw(picoflash_copy_error)
     end,
-    rebar_api:info("Successfully loaded ~s application to device at path ~s.", [App, PicoPath]),
+    rebar_api:info("Successfully loaded ~s application to the device.", [App]),
     ok.

--- a/src/atomvm_uf2create_provider.erl
+++ b/src/atomvm_uf2create_provider.erl
@@ -30,7 +30,7 @@
 -define(DEPS, [packbeam]).
 -define(OPTS, [
     {family_id, $f, "family_id", string,
-        "Device family or flavor of uf2 file to create (default rp2040)"},
+        "Device family or flavor of uf2 file to create (default universal)"},
     {output, $o, "output", string, "Output path/name"},
     {start, $s, "start", string, "Start address for the uf2 binary (default 0x10180000)"},
     {input, $i, "input", string, "Input avm file to convert to uf2"}
@@ -38,7 +38,7 @@
 
 -define(DEFAULT_OPTS, #{
     start => os:getenv("ATOMVM_PICO_APP_START", "0x10180000"),
-    family_id => os:getenv("ATOMVM_PICO_UF2_FAMILY", rp2040)
+    family_id => os:getenv("ATOMVM_PICO_UF2_FAMILY", universal)
 }).
 
 %%
@@ -84,10 +84,10 @@ do(State) ->
     catch
         C:E:S ->
             rebar_api:error(
-                "An error occurred in the ~p task.  Class=~p Error=~p Stacktrace=~p~n", [
-                    ?PROVIDER, C, E, S
-                ]
+                "An error occurred in the ~p task.  Error=~p",
+                [?PROVIDER, E]
             ),
+            rebar_api:debug("Class=~p, Error=~p~nSTACKTRACE:~n~p~n", [C, E, S]),
             {error, E}
     end.
 

--- a/src/darwin_ioreg.erl
+++ b/src/darwin_ioreg.erl
@@ -1,0 +1,70 @@
+%
+% This file is part of atomvm_rebar3_plugin.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(darwin_ioreg).
+
+-export([
+    pico_callout_devices/0
+]).
+
+% Parse ioreg output to find out the callout devices attached to Pico.
+% No pico connected:
+% 1> darwin_ioreg:pico_callout_devices().
+% []
+% One pico connected:
+% 2> darwin_ioreg:pico_callout_devices().
+% [<<"/dev/cu.usbmodem14401">>]
+% Two picos connected:
+% 3> darwin_ioreg:pico_callout_devices().
+% [<<"/dev/cu.usbmodem14401">>,<<"/dev/cu.usbmodem14301">>]
+-spec pico_callout_devices() -> [unicode:unicode_binary()].
+pico_callout_devices() ->
+    ResultStr = os:cmd("ioreg -r -n IOSerialBSDClient -t"),
+    ResultBin = list_to_binary(ResultStr),
+    ResultLines = binary:split(ResultBin, <<"\n">>, [global]),
+    parse(ResultLines, []).
+
+parse([<<"+-o Root  ", _/binary>> | T], Acc) ->
+    parse_tree(T, root, Acc);
+parse([<<" ", Rest/binary>> | T], Acc) ->
+    parse([Rest | T], Acc);
+parse([<<>> | T], Acc) ->
+    parse(T, Acc);
+parse([], Acc) ->
+    Acc.
+
+parse_tree([<<" ", Rest/binary>> | T], IsPico, Acc) ->
+    parse_tree([Rest | T], IsPico, Acc);
+parse_tree([<<"+-o Pico@", _/binary>> | T], root, Acc) ->
+    parse_tree(T, true, Acc);
+parse_tree([<<"+-o IOSerialBSDClient ", _/binary>> | T], IsPico, Acc) ->
+    parse_ioserialbsdclient(T, IsPico, Acc);
+parse_tree([<<"+-o ", _/binary>> | T], IsPico, Acc) ->
+    parse_tree(T, IsPico, Acc).
+
+parse_ioserialbsdclient([<<" ", Rest/binary>> | T], IsPico, Acc) ->
+    parse_ioserialbsdclient([Rest | T], IsPico, Acc);
+parse_ioserialbsdclient([<<"\"IOCalloutDevice\" = \"", Rest/binary>> | T], true, Acc) ->
+    [CallOut | _] = binary:split(Rest, <<"\"">>),
+    parse_ioserialbsdclient(T, true, [CallOut | Acc]);
+parse_ioserialbsdclient([<<"}">> | T], _IsPico, Acc) ->
+    parse(T, Acc);
+parse_ioserialbsdclient([_Other | T], IsPico, Acc) ->
+    parse_ioserialbsdclient(T, IsPico, Acc).


### PR DESCRIPTION
Updates the pico_flash provider for RP2350 parity with RP2040 devices, including auto detection of mount points and reset device. Updates the uf2create to default to "universal" uf2 format. These changes allow flashing any RP2 devices using the default settings in most circumstances. The path to picotool has also been made a configurable option if users have multiple versions installed and don't want to use the first one found in PATH, or if the tool is not installed in PATH.

Closes #40
Closes #44