### PR TITLE
Fix dialyzer warning in uf2create provider

### DIFF
--- a/src/atomvm_uf2create_provider.erl
+++ b/src/atomvm_uf2create_provider.erl
@@ -38,7 +38,7 @@
 
 -define(DEFAULT_OPTS, #{
     start => os:getenv("ATOMVM_PICO_APP_START", "0x10180000"),
-    family_id => os:getenv("ATOMVM_PICO_UF2_FAMILY", universal)
+    family_id => os:getenv("ATOMVM_PICO_UF2_FAMILY", "universal")
 }).
 
 %%


### PR DESCRIPTION
Fixes a dialyzer warning about breaking the contract for the return value from os:get_env/2 in the uf2create task.