### PR TITLE
Add workflow automation to publish docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,67 @@
+#
+#  Copyright 2025 Winford (Uncle Grumpy) <winford@object.stream>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+# This is a workflow for atomvm/atomvm_packbeam to publish documentation to GitHub Pages
+
+name: Publish Docs
+
+on:
+  # Triggers the workflow on tags
+  push:
+   branches:
+      - 'master'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+
+  build:
+    runs-on: ubuntu-24.04
+    container: erlang:28
+    steps:
+
+    - name: "Checkout code"
+      uses: actions/checkout@v5
+
+    - name: "Setup Pages"
+      uses: actions/configure-pages@v5
+
+    - name: "Build Docs"
+      run: |
+        rebar3 as doc ex_doc
+
+    - name: Upload pages artifact
+      ## Must use v3 for now due to issue actions/deploy-pages#389
+      uses: actions/upload-pages-artifact@v3
+      with:
+        name: github-pages
+        path: ./docs
+
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-24.04
+    steps:
+
+      - name: "Setup Pages"
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        if: ${{ github.repository == 'atomvm/atomvm_rebar3_plugin' }}
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 A [`rebar3`](https://rebar3.org) plugin for simplifying development of Erlang applications targeted for the [AtomVM](http://github.com/atomvm/AtomVM) Erlang abstract machine.
 
+[Releases](https://hex.pm/packages/atomvm_rebar3_plugin) and
+[accompanying documentation](https://hexdocs.pm/atomvm_rebar3_plugin/readme.html) are available on
+[hex.pm](https://hex.pm). The documentation for the current master branch is always available from
+the [`atomvm_rebar3_plugin` GitHub pages](https://atomvm.github.io/atomvm_rebar3_plugin/readme.html).
+
 ## Quick Start
 
 Create or edit the `$HOME/.config/rebar3/rebar.config` file to include the `atomvm_rebar3_plugin` [`rebar3`](https://rebar3.org) plugin:


### PR DESCRIPTION
Automates the publication of documentation to github pages when changes are merged to the master branch. This will keep the github pages in sync with the master barnch and users can use the docs published to hex.pm for release versions