### PR TITLE
Bump packbeam dependency to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update dependancy version of atomvm_packbeam to 0.7.5
+- Update dependancy version of atomvm_packbeam to 0.8.0
 
 ### Added
 - Added dialyzer task to simplify running dialyzer on AtomVM applications.

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {atomvm_packbeam, "0.7.5"},
+    {atomvm_packbeam, "0.8.0"},
     {uf2tool, "1.1.0"}
 ]}.
 


### PR DESCRIPTION
Change packbeam dependency to use the latest version of atomvm_packbeam.