### PR TITLE
Add removal warnings to legacy providers

### DIFF
--- a/src/legacy_esp32_flash_provider.erl
+++ b/src/legacy_esp32_flash_provider.erl
@@ -56,7 +56,7 @@ init(State) ->
         {short_desc, "A rebar plugin to flash packbeam files to ESP32 devices (DEPRECATED)"},
         {desc,
             "A rebar plugin to flash packbeam files to ESP32 devices.~n~n"
-            "IMPORTANT! this plugin has been DEPRECATED!~n"
+            "IMPORTANT! this plugin has been DEPRECATED and will be REMOVED in the 0.9.0 release!~n"
             "Use `rebar3 atomvm esp32_flash`, instead.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
@@ -64,6 +64,7 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     rebar_api:warn("DEPRECATED The esp32_flash tool has been moved under the atomvm namespace", []),
+    rebar_api:warn("This legacy provider will be REMOVED in the 0.9.0 release.", []),
     atomvm_esp32_flash_provider:do(State).
 
 -spec format_error(any()) -> iolist().

--- a/src/legacy_packbeam_provider.erl
+++ b/src/legacy_packbeam_provider.erl
@@ -57,7 +57,7 @@ init(State) ->
         {short_desc, "A rebar plugin to create packbeam files (DEPRECATED)"},
         {desc,
             "A rebar plugin to create packbeam files.~n~n"
-            "IMPORTANT! this plugin has been DEPRECATED!~n"
+            "IMPORTANT! this plugin has been DEPRECATED and will be REMOVED in the 0.9.0 release!~n"
             "Use `rebar3 atomvm packbeam`, instead.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
@@ -65,6 +65,7 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     rebar_api:warn("DEPRECATED The packbeam tool has been moved under the atomvm namespace", []),
+    rebar_api:warn("This legacy provider will be REMOVED in the 0.9.0 release.", []),
     atomvm_packbeam_provider:do(State).
 
 -spec format_error(any()) -> iolist().

--- a/src/legacy_stm32_flash_provider.erl
+++ b/src/legacy_stm32_flash_provider.erl
@@ -54,7 +54,7 @@ init(State) ->
         {short_desc, "A rebar plugin to flash packbeam files to STM32 devices (DEPRECATED)"},
         {desc,
             "A rebar plugin to flash packbeam files to STM32 devices.~n~n"
-            "IMPORTANT! this plugin has been DEPRECATED!~n"
+            "IMPORTANT! this plugin has been DEPRECATED and will be REMOVED in the 0.9.0 release!~n"
             "Use `rebar3 atomvm stm32_flash`, instead.~n"}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
@@ -62,6 +62,7 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     rebar_api:warn("DEPRECATED The stm32_flash tool has been moved under the atomvm namespace", []),
+    rebar_api:warn("This legacy provider will be REMOVED in the 0.9.0 release.", []),
     atomvm_stm32_flash_provider:do(State).
 
 -spec format_error(any()) -> iolist().


### PR DESCRIPTION
Updates deprecation warnings with removal notices for the 0.9.0 release, in both runtime warnings, and provider description's for the legacy providers outside of the atomvm namespace. These warnings should be in place before the 0.8.0 release.