### PR TITLE
Dialyzer use source files for base plt

### DIFF
--- a/src/atomvm_dialyzer_provider.erl
+++ b/src/atomvm_dialyzer_provider.erl
@@ -190,7 +190,7 @@ do_build_base_plt(Config) ->
     PLT = base_plt_absname(Config),
     try
         dialyzer:run([
-            {analysis_type, plt_build}, {init_plt, PLT}, {output_plt, PLT}, {files_rec, BEAMdir}
+            {analysis_type, plt_build}, {init_plt, PLT}, {output_plt, PLT}, {files, BEAMdir}
         ])
     of
         [] ->
@@ -286,7 +286,7 @@ get_base_beam_path_list(Base) ->
             fun(E, Acc) ->
                 [
                     filelib:wildcard(
-                        Base ++ "/{lib,libs}/" ++ atom_to_list(E) ++ "*/**/{ebin,beams}"
+                        Base ++ "/{lib,libs}/" ++ atom_to_list(E) ++ "*/**/src"
                     )
                     | Acc
                 ]


### PR DESCRIPTION
Use AtomVM library source files to build base plt so dialyzer does not complain about finding multiple (jit) modules with the same name when using beam files.