### PR TITLE
Update atomvm_packbeam dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.6] (unreleased)
 
-### Changed
-- Update dependancy version of atomvm_packbeam to 0.7.5
-- Update dependancy version of atomvm_packbeam to 0.8.0
-
 ### Added
 - Added dialyzer task to simplify running dialyzer on AtomVM applications.
 - Added support for rp2350 devices to allow for default detection of the device mount path.
@@ -29,6 +25,7 @@ rp2040 or rp2350 devices.
 - The `pico_flash` task now checks that a device is an RP2 platform before resetting to `BOOTSEL`
 mode, preventing interference with other MCUs that may be attached to the host system.
 - The `pico_flash` task now aborts on all errors rather than trying to continue after a failure.
+- Update dependency version of atomvm_packbeam to 0.8.1
 
 ## [0.7.5] (2025.05.27)
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ The `pico_flash` task depends on the `uf2create` task which in turn depends on t
     ===> Compiling hex_core
     ===> Compiling verl
     ===> Compiling rebar3_hex
-    ===> Fetching atomvm_packbeam v0.7.4
+    ===> Fetching atomvm_packbeam v0.8.1
     ===> Fetching rebar3_proper v0.12.1
     ===> Analyzing applications...
     ===> Compiling rebar3_proper

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {atomvm_packbeam, "0.8.0"},
+    {atomvm_packbeam, "0.8.1"},
     {uf2tool, "1.1.0"}
 ]}.
 


### PR DESCRIPTION
Update to depend on the latest (0.8.1) release of atomvm_packbeam. Consolidates duplicated "Changed" section of CHANGELOG.md.