### PR TITLE
Allow passing packbeam options from other tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ Any setting specified on the command line take precedence over settings in `reba
 
 The `packbeam` task depends on the `compile` task, so any changes to modules in the project will automatically get rebuilt when running the `packbeam` task.
 
+Packbeam options may also be passed through from other higher level tasks such as `uf2create` or
+the various flash tasks for mcu platforms. When options for packbeam are given to other tasks use
+the long version, or the capitalized version of the short parameters, for example `-P` or
+`--prune` intstead of `-p`.
+
 #### External Dependencies
 
 If you already have AVM modules are not available via `rebar3`, you can direct the `packbeam` task to these AVM files via the `--external` (or `-e`) flag, e.g.,

--- a/src/atomvm_esp32_flash_provider.erl
+++ b/src/atomvm_esp32_flash_provider.erl
@@ -32,7 +32,14 @@
     {chip, $c, "chip", string, "ESP chip (default auto)"},
     {port, $p, "port", string, "Device port (default /dev/ttyUSB0)"},
     {baud, $b, "baud", integer, "Baud rate (default 115200)"},
-    {offset, $o, "offset", string, "Offset (default 0x210000)"}
+    {offset, $o, "offset", string, "Offset (default 0x210000)"},
+    {prune, $P, "prune", boolean, "Prune unused modules with packbeam"},
+    {external, $E, "external", string, "External modules to add to packed AVM"},
+    {force, $F, "force", boolean, "Force packbeam to repack"},
+    {application, $A, "application", boolean, "Build and flash an OTP application"},
+    {remove_lines, $R, "remove_lines", boolean,
+        "Remove line information from generated AVM files (off by default)"},
+    {list, $L, "list", boolean, "List the contents of AVM files after creation"}
 ]).
 
 -define(DEFAULT_OPTS, #{

--- a/src/atomvm_pico_flash_provider.erl
+++ b/src/atomvm_pico_flash_provider.erl
@@ -35,7 +35,14 @@
         "Path to pico device (Defaults Linux: /run/media/${USER}/RPI-RP2, MacOS: /Volumes/RPI-RP2)"},
     {reset, $r, "reset", string,
         "Path to serial device to reset before flashing (Defaults Linux: /dev/ttyACM0, MacOS: /dev/cu.usbmodem14*)"},
-    {picotool, $t, "picotool", string, "Path to picotool utility (Default is to search in PATH)"}
+    {picotool, $t, "picotool", string, "Path to picotool utility (Default is to search in PATH)"},
+    {prune, $P, "prune", boolean, "Prune unused modules with packbeam"},
+    {external, $E, "external", string, "External modules to add to packed AVM"},
+    {force, $F, "force", boolean, "Force packbeam to repack"},
+    {application, $A, "application", boolean, "Build and flash an OTP application"},
+    {remove_lines, $R, "remove_lines", boolean,
+        "Remove line information from generated AVM files (off by default)"},
+    {list, $L, "list", boolean, "List the contents of AVM files after creation"}
 ]).
 
 %%

--- a/src/atomvm_stm32_flash_provider.erl
+++ b/src/atomvm_stm32_flash_provider.erl
@@ -32,7 +32,14 @@
 -define(DEPS, [packbeam]).
 -define(OPTS, [
     {stflash, $s, "stflash", string, "Path to st-flash"},
-    {offset, $o, "offset", string, "Offset (default 0x8080000)"}
+    {offset, $o, "offset", string, "Offset (default 0x8080000)"},
+    {prune, $P, "prune", boolean, "Prune unused modules with packbeam"},
+    {external, $E, "external", string, "External modules to add to packed AVM"},
+    {force, $F, "force", boolean, "Force packbeam to repack"},
+    {application, $A, "application", boolean, "Build and flash an OTP application"},
+    {remove_lines, $R, "remove_lines", boolean,
+        "Remove line information from generated AVM files (off by default)"},
+    {list, $L, "list", boolean, "List the contents of AVM files after creation"}
 ]).
 
 -define(DEFAULT_OPTS, #{

--- a/src/atomvm_uf2create_provider.erl
+++ b/src/atomvm_uf2create_provider.erl
@@ -33,7 +33,14 @@
         "Device family or flavor of uf2 file to create (default universal)"},
     {output, $o, "output", string, "Output path/name"},
     {start, $s, "start", string, "Start address for the uf2 binary (default 0x10180000)"},
-    {input, $i, "input", string, "Input avm file to convert to uf2"}
+    {input, $i, "input", string, "Input avm file to convert to uf2"},
+    {prune, $P, "prune", boolean, "Prune unused modules with packbeam"},
+    {external, $E, "external", string, "External modules to add to packed AVM"},
+    {force, $F, "force", boolean, "Force packbeam to repack"},
+    {application, $A, "application", boolean, "Build and flash an OTP application"},
+    {remove_lines, $R, "remove_lines", boolean,
+        "Remove line information from generated AVM files (off by default)"},
+    {list, $L, "list", boolean, "List the contents of AVM files after creation"}
 ]).
 
 -define(DEFAULT_OPTS, #{


### PR DESCRIPTION
Update the platform_flash_providers and uf2create provider to pass options to packbeam. Capitalized versions of the short option are used for pass-through to avoid conflicts with existing task options and to maintain some consistency and clarity about which options are passed to packbeam and which are consumed by the task. The `start` option has not been exposed, since this should be determined by other means, and the long and short versions of the option collides with other tasks options.

Closes #65